### PR TITLE
Explicitly return error

### DIFF
--- a/AirGradient.cpp
+++ b/AirGradient.cpp
@@ -303,7 +303,7 @@ TMP_RH AirGradient::periodicFetchData() //
     return result;
   }
   else
-    returnError(error);
+    return returnError(error);
 }
 
 TMP_RH_ErrorCode AirGradient::periodicStop() {


### PR DESCRIPTION
The AirGradient library can not be used currently with PlatformIO due to a missing return statement on this code.