### PR TITLE
Use modbus library to communicate with CO2 sensor

### DIFF
--- a/AirGradient.h
+++ b/AirGradient.h
@@ -7,6 +7,9 @@
 #ifndef AirGradient_h
 #define AirGradient_h
 
+#ifdef AIRGRADIENT_MODBUS
+#include <ModbusRTU.h>
+#endif
 #include <SoftwareSerial.h>
 #include <Print.h>
 #include "Stream.h"
@@ -254,6 +257,10 @@ class AirGradient
     void CO2_Init(int,int,int);
     int getCO2(int numberOfSamplesToTake = 5);
     int getCO2_Raw();
+
+#ifdef AIRGRADIENT_MODBUS
+    ModbusRTU *_modbus;
+#endif
     SoftwareSerial *_SoftSerial_CO2;
 
     //CO2 VARIABLES PUBLIC END
@@ -319,6 +326,11 @@ class AirGradient
 
     //CO2 VARABLES PUBLIC START
     char Char_CO2[10];
+
+#ifdef AIRGRADIENT_MODBUS
+    Modbus::ResultCode modbus_result;
+    bool modbus_cb(Modbus::ResultCode event, uint16_t transactionId, void* data);
+#endif
 
     //CO2 VARABLES PUBLIC END
     //MHZ19 VARABLES PUBLIC START


### PR DESCRIPTION
The SenseAir S8 used in AirGradient is accessed via the modbus protocol, over an RS232 serial bus.
The current implementation has dealt with this through a minimal modbus layer, which has led to a number of problems in the past (problems with timing, incorrect readings).

This patch implements the CO2 sensor access through a modbus library, which implements the entire low level communication and provides proper checksum testing and other error handling.

The changes are in the `AirGradient::getCO2_Raw` method, and the external behaviour of the method is unchanged.

The modbus library chosen is emelianov/modbus-esp8266, which needs to be added to the dependency list in Arduino.

This change increases the size of the sketch by roughly 8kB on an ESP8266 board.

This change currently gates the new implementation behind a feature flag (`AIRGRADIENT_MODBUS`) for easier testing. This macro needs to be defined in the compile stage.

I have run a sensor with this change for a week, and have encountered no further spurious CO2 readings, while before there was roughly one per day.