### PR TITLE
mention all required libraries for ONE v9

### DIFF
--- a/examples/ONE_V9/ONE_V9.ino
+++ b/examples/ONE_V9/ONE_V9.ino
@@ -14,6 +14,8 @@ The codes needs the following libraries installed:
 "Sensirion Gas Index Algorithm" by Sensation Version 3.2.1
 "Arduino-SHT" by Johannes Winkelmann Version 1.2.2
 "Adafruit NeoPixel" by Adafruit Version 1.11.0
+"S8_UART" by Josep Comas Version 1.0.1
+"PMS Library" by Mariusz Kacki patched by Achim Haug: https://www.airgradient.com/blog/patching-pms-library-for-plantower-pms5003t/
 
 Configuration:
 Please set in the code below the configuration parameters.


### PR DESCRIPTION
There are two additional libraries required to compile the code for the ONE v9.
I found the solution in this blog post: https://www.cnx-software.com/2023/11/29/airgradient-one-kit-review-an-open-source-indoor-air-quality-monitor/
The patched PMS library version is required, because the original is missing the PM_RAW_0_3 variable.