### PR TITLE
Fix compilation warning

### DIFF
--- a/AirGradient.cpp
+++ b/AirGradient.cpp
@@ -681,8 +681,8 @@ uint8_t AirGradient::calculateCrc(uint8_t data[])
 
 TMP_RH AirGradient::returnError(TMP_RH_ErrorCode error) {
   TMP_RH result;
-  result.t = NULL;
-  result.rh = NULL;
+  result.t = -128;
+  result.rh = -128;
 
   result.t_char[0] = 'N';
   result.t_char[1] = 'U';


### PR DESCRIPTION
In the Arduino IDE there are compilation errors like:

```
AirGradient_Air_Quality_Sensor/AirGradient.cpp:684:14: warning: converting to non-pointer type 'float' from NULL [-Wconversion-null]
  684 |   result.t = NULL;
      |              ^~~~
AirGradient_Air_Quality_Sensor/AirGradient.cpp:685:15: warning: converting to non-pointer type 'int' from NULL [-Wconversion-null]
  685 |   result.rh = NULL;
```

Just setting to `-128` since they are obviously wrong.