### PR TITLE
Fix: Timing between loop actions

### DIFF
--- a/examples/DIY_BASIC/DIY_BASIC.ino
+++ b/examples/DIY_BASIC/DIY_BASIC.ino
@@ -110,7 +110,7 @@ void loop()
 void updateCo2()
 {
     if (currentMillis - previousCo2 >= co2Interval) {
-      previousCo2 += co2Interval;
+      previousCo2 = currentMillis;
       Co2 = ag.getCO2_Raw();
       Serial.println(String(Co2));
     }
@@ -119,7 +119,7 @@ void updateCo2()
 void updatePm25()
 {
     if (currentMillis - previousPm25 >= pm25Interval) {
-      previousPm25 += pm25Interval;
+      previousPm25 = currentMillis;
       pm25 = ag.getPM2_Raw();
       Serial.println(String(pm25));
     }
@@ -128,7 +128,7 @@ void updatePm25()
 void updateTempHum()
 {
     if (currentMillis - previousTempHum >= tempHumInterval) {
-      previousTempHum += tempHumInterval;
+      previousTempHum = currentMillis;
     if (sht.readSample()) {
       Serial.print("SHT:\n");
       Serial.print("  RH: ");
@@ -148,7 +148,7 @@ void updateTempHum()
 
 void updateOLED() {
    if (currentMillis - previousOled >= oledInterval) {
-     previousOled += oledInterval;
+     previousOled = currentMillis;
 
     String ln1;
     String ln2;
@@ -186,7 +186,7 @@ void updateOLED2(String ln1, String ln2, String ln3) {
 
 void sendToServer() {
    if (currentMillis - previoussendToServer >= sendToServerInterval) {
-     previoussendToServer += sendToServerInterval;
+     previoussendToServer = currentMillis;
 
       String payload = "{\"wifi\":" + String(WiFi.RSSI())
       + (Co2 < 0 ? "" : ", \"rco2\":" + String(Co2))

--- a/examples/DIY_OUTDOOR/DIY_OUTDOOR.ino
+++ b/examples/DIY_OUTDOOR/DIY_OUTDOOR.ino
@@ -84,7 +84,7 @@ void updatePm1()
       delay(400);
       digitalWrite(D7, LOW);
       Serial.println("updatePm1: "+String(pm1Position));
-      previousPm1 += pm1Interval;
+      previousPm1 = currentMillis;
         pms.requestRead();
         if (pms.readUntil(data)){
           Serial.println("success read");
@@ -114,7 +114,7 @@ void updatePm2()
 {
     if (currentMillis - previousPm2 >= pm2Interval) {
       Serial.println("updatePm2: "+String(pm2Position));
-      previousPm2 += pm2Interval;
+      previousPm2 = currentMillis;
       pms2.requestRead();
           if (pms2.readUntil(data2)){
             int pm2 = data2.PM_AE_UG_2_5;

--- a/examples/DIY_OUTDOOR_C3_1PST/DIY_OUTDOOR_C3_1PST.ino
+++ b/examples/DIY_OUTDOOR_C3_1PST/DIY_OUTDOOR_C3_1PST.ino
@@ -189,7 +189,7 @@ void updateTVOC() {
   }
 
   if (currentMillis - previousTVOC >= tvocInterval) {
-previousTVOC += tvocInterval;
+previousTVOC = currentMillis;
 if (error) {
    TVOC = -1;
     NOX = -1;
@@ -204,7 +204,7 @@ if (error) {
 
 void updateCo2() {
   if (currentMillis - previousCo2 >= co2Interval) {
-    previousCo2 += co2Interval;
+    previousCo2 = currentMillis;
     Co2 = sensor_S8 -> get_co2();
     //Serial.println(String(Co2));
   }
@@ -212,7 +212,7 @@ void updateCo2() {
 
 void updatePm() {
   if (currentMillis - previousPm >= pmInterval) {
-    previousPm += pmInterval;
+    previousPm = currentMillis;
     if (pms1.readUntil(data1, 2000)) {
       pm01 = data1.PM_AE_UG_1_0;
       pm25 = data1.PM_AE_UG_2_5;
@@ -241,7 +241,7 @@ void sendPing() {
 
 void sendToServer() {
   if (currentMillis - previoussendToServer >= sendToServerInterval) {
-    previoussendToServer += sendToServerInterval;
+    previoussendToServer = currentMillis;
     String payload = "{\"wifi\":" + String(WiFi.RSSI()) +
       (Co2 < 0 ? "" : ", \"rco2\":" + String(Co2)) +
       (pm01 < 0 ? "" : ", \"pm01\":" + String(pm01)) +

--- a/examples/DIY_PRO/DIY_PRO.ino
+++ b/examples/DIY_PRO/DIY_PRO.ino
@@ -107,7 +107,7 @@ void loop()
 void updateCo2()
 {
     if (currentMillis - previousCo2 >= co2Interval) {
-      previousCo2 += co2Interval;
+      previousCo2 = currentMillis;
       Co2 = ag.getCO2_Raw();
       Serial.println(String(Co2));
     }
@@ -116,7 +116,7 @@ void updateCo2()
 void updatePm25()
 {
     if (currentMillis - previousPm25 >= pm25Interval) {
-      previousPm25 += pm25Interval;
+      previousPm25 = currentMillis;
       pm25 = ag.getPM2_Raw();
       Serial.println(String(pm25));
     }
@@ -125,7 +125,7 @@ void updatePm25()
 void updateTempHum()
 {
     if (currentMillis - previousTempHum >= tempHumInterval) {
-      previousTempHum += tempHumInterval;
+      previousTempHum = currentMillis;
       TMP_RH result = ag.periodicFetchData();
       temp = result.t;
       hum = result.rh;
@@ -135,7 +135,7 @@ void updateTempHum()
 
 void updateOLED() {
    if (currentMillis - previousOled >= oledInterval) {
-     previousOled += oledInterval;
+     previousOled = currentMillis;
 
     String ln3;
     String ln1 = "PM:" + String(pm25) +  " AQI:" + String(PM_TO_AQI_US(pm25)) ;
@@ -164,7 +164,7 @@ void updateOLED2(String ln1, String ln2, String ln3) {
 
 void sendToServer() {
    if (currentMillis - previoussendToServer >= sendToServerInterval) {
-     previoussendToServer += sendToServerInterval;
+     previoussendToServer = currentMillis;
 
       String payload = "{\"wifi\":" + String(WiFi.RSSI())
       + (Co2 < 0 ? "" : ", \"rco2\":" + String(Co2))

--- a/examples/DIY_PRO_V3_7/DIY_PRO_V3_7.ino
+++ b/examples/DIY_PRO_V3_7/DIY_PRO_V3_7.ino
@@ -291,7 +291,7 @@ void updateTVOC()
     }
 
     if (currentMillis - previousTVOC >= tvocInterval) {
-      previousTVOC += tvocInterval;
+      previousTVOC = currentMillis;
       TVOC = voc_algorithm.process(srawVoc);
       NOX = nox_algorithm.process(srawNox);
       Serial.println(String(TVOC));
@@ -301,7 +301,7 @@ void updateTVOC()
 void updateCo2()
 {
     if (currentMillis - previousCo2 >= co2Interval) {
-      previousCo2 += co2Interval;
+      previousCo2 = currentMillis;
       Co2 = ag.getCO2_Raw();
       Serial.println(String(Co2));
     }
@@ -310,7 +310,7 @@ void updateCo2()
 void updatePm25()
 {
     if (currentMillis - previousPm25 >= pm25Interval) {
-      previousPm25 += pm25Interval;
+      previousPm25 = currentMillis;
       pm25 = ag.getPM2_Raw();
       Serial.println(String(pm25));
     }
@@ -319,7 +319,7 @@ void updatePm25()
 void updateTempHum()
 {
     if (currentMillis - previousTempHum >= tempHumInterval) {
-      previousTempHum += tempHumInterval;
+      previousTempHum = currentMillis;
       TMP_RH result = ag.periodicFetchData();
       temp = result.t;
       hum = result.rh;
@@ -329,7 +329,7 @@ void updateTempHum()
 
 void updateOLED() {
    if (currentMillis - previousOled >= oledInterval) {
-     previousOled += oledInterval;
+     previousOled = currentMillis;
 
     String ln3;
     String ln1;
@@ -365,7 +365,7 @@ void updateOLED2(String ln1, String ln2, String ln3) {
 
 void sendToServer() {
    if (currentMillis - previoussendToServer >= sendToServerInterval) {
-     previoussendToServer += sendToServerInterval;
+     previoussendToServer = currentMillis;
       String payload = "{\"wifi\":" + String(WiFi.RSSI())
       + (Co2 < 0 ? "" : ", \"rco2\":" + String(Co2))
       + (pm25 < 0 ? "" : ", \"pm02\":" + String(pm25))

--- a/examples/DIY_PRO_V4_2/DIY_PRO_V4_2.ino
+++ b/examples/DIY_PRO_V4_2/DIY_PRO_V4_2.ino
@@ -283,7 +283,7 @@ void updateTVOC()
     }
 
     if (currentMillis - previousTVOC >= tvocInterval) {
-      previousTVOC += tvocInterval;
+      previousTVOC = currentMillis;
       TVOC = voc_algorithm.process(srawVoc);
       NOX = nox_algorithm.process(srawNox);
       Serial.println(String(TVOC));
@@ -293,7 +293,7 @@ void updateTVOC()
 void updateCo2()
 {
     if (currentMillis - previousCo2 >= co2Interval) {
-      previousCo2 += co2Interval;
+      previousCo2 = currentMillis;
       Co2 = ag.getCO2_Raw();
       Serial.println(String(Co2));
     }
@@ -302,7 +302,7 @@ void updateCo2()
 void updatePm()
 {
     if (currentMillis - previousPm >= pmInterval) {
-      previousPm += pmInterval;
+      previousPm = currentMillis;
       pm01 = ag.getPM1_Raw();
       pm25 = ag.getPM2_Raw();
       pm10 = ag.getPM10_Raw();
@@ -314,7 +314,7 @@ void updatePm()
 void updateTempHum()
 {
     if (currentMillis - previousTempHum >= tempHumInterval) {
-      previousTempHum += tempHumInterval;
+      previousTempHum = currentMillis;
 
       if (sht.readSample()) {
       Serial.print("SHT:\n");
@@ -335,7 +335,7 @@ void updateTempHum()
 
 void updateOLED() {
    if (currentMillis - previousOled >= oledInterval) {
-     previousOled += oledInterval;
+     previousOled = currentMillis;
 
     String ln3;
     String ln1;
@@ -371,7 +371,7 @@ void updateOLED2(String ln1, String ln2, String ln3) {
 
 void sendToServer() {
    if (currentMillis - previoussendToServer >= sendToServerInterval) {
-     previoussendToServer += sendToServerInterval;
+     previoussendToServer = currentMillis;
       String payload = "{\"wifi\":" + String(WiFi.RSSI())
       + (Co2 < 0 ? "" : ", \"rco2\":" + String(Co2))
       + (pm01 < 0 ? "" : ", \"pm01\":" + String(pm01))

--- a/examples/ONE_V9/ONE_V9.ino
+++ b/examples/ONE_V9/ONE_V9.ino
@@ -258,7 +258,7 @@ void updateTVOC() {
   }
 
   if (currentMillis - previousTVOC >= tvocInterval) {
-    previousTVOC += tvocInterval;
+    previousTVOC = currentMillis;
     if (error) {
       TVOC = -1;
       NOX = -1;
@@ -274,7 +274,7 @@ void updateTVOC() {
 
 void updateCo2() {
   if (currentMillis - previousCo2 >= co2Interval) {
-    previousCo2 += co2Interval;
+    previousCo2 = currentMillis;
     Co2 = sensor_S8 -> get_co2();
     Serial.println(String(Co2));
   }
@@ -282,7 +282,7 @@ void updateCo2() {
 
 void updatePm() {
   if (currentMillis - previousPm >= pmInterval) {
-    previousPm += pmInterval;
+    previousPm = currentMillis;
     if (pms1.readUntil(data1, 2000)) {
       pm01 = data1.PM_AE_UG_1_0;
       pm25 = data1.PM_AE_UG_2_5;
@@ -299,7 +299,7 @@ void updatePm() {
 
 void updateTempHum() {
   if (currentMillis - previousTempHum >= tempHumInterval) {
-    previousTempHum += tempHumInterval;
+    previousTempHum = currentMillis;
 
     if (sht.readSample()) {
       temp = sht.getTemperature();
@@ -314,7 +314,7 @@ void updateTempHum() {
 
 void updateOLED() {
   if (currentMillis - previousOled >= oledInterval) {
-    previousOled += oledInterval;
+    previousOled = currentMillis;
 
     String ln3;
     String ln1;
@@ -518,7 +518,7 @@ void updateOLED3() {
 
 void sendToServer() {
   if (currentMillis - previoussendToServer >= sendToServerInterval) {
-    previoussendToServer += sendToServerInterval;
+    previoussendToServer = currentMillis;
     String payload = "{\"wifi\":" + String(WiFi.RSSI()) +
       (Co2 < 0 ? "" : ", \"rco2\":" + String(Co2)) +
       (pm01 < 0 ? "" : ", \"pm01\":" + String(pm01)) +


### PR DESCRIPTION
Use the current time for timestamping the previous action time.

This prevents bursting behaviour in case of `currentMillis - previousAction > 2*actionInterval`.
Additionally the change should make the logic slightly more readable.

## Testing

* Tested on ONE_V9.ino, which maintains measurement interval close to `actionInterval`.

## Notes

While `previousAction = millis();` would be more readable and precise, that caused AirGradient One to sample TVOC about every 2000millis compared to 1000millis that the current change does.