### PR TITLE
Delete unused displayTop global

### DIFF
--- a/examples/ONE_V9/ONE_V9.ino
+++ b/examples/ONE_V9/ONE_V9.ino
@@ -93,9 +93,6 @@ boolean inF = false;
 // PM2.5 in US AQI (default ug/m3)
 boolean inUSAQI = false;
 
-// Display Position
-boolean displayTop = true;
-
 // use RGB LED Bar
 boolean useRGBledBar = true;
 


### PR DESCRIPTION
We never use this variable, so there's no reason to declare or define it.