### PR TITLE
Handle humidity measurement as a float

### DIFF
--- a/examples/ONE_V9/ONE_V9.ino
+++ b/examples/ONE_V9/ONE_V9.ino
@@ -128,7 +128,7 @@ int pm10 = -1;
 const int tempHumInterval = 5000;
 unsigned long previousTempHum = 0;
 float temp;
-int hum;
+float hum;
 
 int buttonConfig = 0;
 int lastState = LOW;
@@ -291,7 +291,7 @@ void updateTempHum() {
     } else {
       Serial.print("Error in readSample()\n");
       temp = -10001;
-      hum = -10001;
+      hum = -10001.0;
     }
   }
 }
@@ -457,12 +457,12 @@ void updateOLED3() {
       u8g2.drawUTF8(1, 10, buf);
     }
 
-    if (hum >= 0) {
-      sprintf(buf, "%d%%", hum);
+    if (hum >= 0.0) {
+      sprintf(buf, "%.0f%%", hum);
     } else {
       sprintf(buf, " -%%");
     }
-    if (hum > 99) {
+    if (hum > 99.0) {
       u8g2.drawStr(97, 10, buf);
     } else {
       u8g2.drawStr(105, 10, buf);

--- a/examples/ONE_V9/ONE_V9.ino
+++ b/examples/ONE_V9/ONE_V9.ino
@@ -231,7 +231,7 @@ void updateTVOC() {
   delay(1000);
 
   compensationT = static_cast < uint16_t > ((temp + 45) * 65535 / 175);
-  compensationRh = static_cast < uint16_t > (hum * 65535 / 100);
+  compensationRh = static_cast < uint16_t > (hum * 65535.0 / 100.0);
 
   if (conditioning_s > 0) {
     error = sgp41.executeConditioning(compensationRh, compensationT, srawVoc);
@@ -538,7 +538,7 @@ void sendToServer() {
       (TVOC < 0 ? "" : ", \"tvoc_index\":" + String(TVOC)) +
       (NOX < 0 ? "" : ", \"nox_index\":" + String(NOX)) +
       ", \"atmp\":" + String(temp) +
-      (hum < 0 ? "" : ", \"rhum\":" + String(hum)) +
+      (hum < 0.0 ? "" : ", \"rhum\":" + String(hum)) +
       ", \"boot\":" + loopCount +
       "}";
 


### PR DESCRIPTION
The `getHumidity` function of the arduino-sht library returns a float

https://github.com/Sensirion/arduino-sht/blob/5e89ae8b9b7eb16675e02d73c417dd79f64b47ae/SHTSensor.h#L148

When AirGradient assigns the return value of `getHumidity` to an `int`, it truncates the decimal portion of the value and reduces precision of the reading. This patch adjusts the type of the `hum` field to a `float` so that we capture the full precision from the SHT sensor.