### PR TITLE
Fix path capitalization

### DIFF
--- a/src/Display/Display.h
+++ b/src/Display/Display.h
@@ -1,7 +1,7 @@
 #ifndef _AIR_GRADIENT_OLED_H_
 #define _AIR_GRADIENT_OLED_H_
 
-#include "../main/BoardDef.h"
+#include "../Main/BoardDef.h"
 #include <Arduino.h>
 #include <Wire.h>
 

--- a/src/S8/S8.h
+++ b/src/S8/S8.h
@@ -1,7 +1,7 @@
 #ifndef _S8_H_
 #define _S8_H_
 
-#include "../main/BoardDef.h"
+#include "../Main/BoardDef.h"
 #include "Arduino.h"
 
 /**

--- a/src/Sgp41/Sgp41.h
+++ b/src/Sgp41/Sgp41.h
@@ -1,7 +1,7 @@
 #ifndef _AIR_GRADIENT_SGP4X_H_
 #define _AIR_GRADIENT_SGP4X_H_
 
-#include "../main/BoardDef.h"
+#include "../Main/BoardDef.h"
 #include <Arduino.h>
 #include <Wire.h>
 

--- a/src/Sht/Sht.h
+++ b/src/Sht/Sht.h
@@ -1,7 +1,7 @@
 #ifndef _SHT_H_
 #define _SHT_H_
 
-#include "../main/BoardDef.h"
+#include "../Main/BoardDef.h"
 #include <Arduino.h>
 #include <Wire.h>
 


### PR DESCRIPTION
This fixes build breakage on case-sensitive filesystems (e.g. Linux) with errors like:

```
src/Display/Display.h:4:10: fatal error: ../main/BoardDef.h: No such file or directory
```