### PR TITLE
Fix TAG not declared error

### DIFF
--- a/examples/ONE_I-9PSL/ONE_I-9PSL.ino
+++ b/examples/ONE_I-9PSL/ONE_I-9PSL.ino
@@ -103,6 +103,8 @@ enum {
   "cleanair" /** default WiFi AP password                                      \
               */
 
+static const char* const TAG = "ONE_I-9PSL";
+
 /**
  * @brief Use use LED bar state
  */

--- a/examples/Open_Air/Open_Air.ino
+++ b/examples/Open_Air/Open_Air.ino
@@ -102,6 +102,8 @@ enum {
   "cleanair" /** default WiFi AP password                                      \
               */
 
+static const char* const TAG = "Open_Air";
+
 /**
  * @brief Use use LED bar state
  */


### PR DESCRIPTION
This fixes the following build breakage when building with "Core Debug Level" set to "Verbose":

```
  examples/ONE_I-9PSL/ONE_I-9PSL.ino: In function 'void mqtt_event_handler(void*, esp_event_base_t, int32_t, void*)':
  examples/ONE_I-9PSL/ONE_I-9PSL.ino:1877:12: error: 'TAG' was not declared in this scope
     ESP_LOGD(TAG,
            ^~~
  examples/ONE_I-9PSL/ONE_I-9PSL.ino:1877:3: note: in expansion of macro 'ESP_LOGD'
     ESP_LOGD(TAG,
```