### PR TITLE
Fix exclude list in GA check

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -22,9 +22,9 @@ jobs:
             board_options: "JTAGAdapter=default,CDCOnBoot=cdc,PartitionScheme=default,CPUFreq=160,FlashMode=qio,FlashFreq=80,FlashSize=4M,UploadSpeed=921600,DebugLevel=verbose,EraseFlash=none"
             core: "esp32:esp32@2.0.11"
         exclude:
-          - example: "BASIC_v4"
+          - example: "BASIC"
             fqbn: "esp32:esp32:esp32c3"
-          - example: "ONE_I-9PSL"
+          - example: "ONE"
             fqbn: "esp8266:esp8266:d1_mini"
           - example: "Open_Air"
             fqbn: "esp8266:esp8266:d1_mini"


### PR DESCRIPTION
This was not updated in a59d5a1bb8510f85a306daf14a879489cc364ad9. This fixes GitHub Actions breakage.