### PR TITLE
[ONE/Prometheus] Use full unit in temperature metric

### DIFF
--- a/examples/ONE/ONE.ino
+++ b/examples/ONE/ONE.ino
@@ -1056,7 +1056,7 @@ void webServerMetricsGet(void) {
       add_metric("temperature",
                  "The ambient temperature as measured by the AirGradient SHT "
                  "sensor, in degrees Celsius",
-                 "gauge", "degc");
+                 "gauge", "celcius");
       add_metric_point("", String(temp));
     }
     if (hum >= 0) {


### PR DESCRIPTION
Please see: https://prometheus.io/docs/practices/naming/#base-units

Also, thanks a lot for this support, I had my own exporter that I can now delete :)