### PR TITLE
Fix MDNS Service Discovery:

### DIFF
--- a/examples/ONE/ONE.ino
+++ b/examples/ONE/ONE.ino
@@ -1091,17 +1091,11 @@ static void webServerInit(void) {
   // Make it possible to query this device from Prometheus/OpenMetrics.
   webServer.on("/metrics", HTTP_GET, webServerMetricsGet);
   webServer.begin();
-  MDNS.addService("http", "tcp", 80);
-  MDNS.addServiceTxt("http", "_tcp", "model", mdnsModelName);
-  MDNS.addServiceTxt("http", "_tcp", "serialno", getDevId());
-  MDNS.addServiceTxt("http", "_tcp", "fw_ver", ag.getVersion());
-  MDNS.addServiceTxt("http", "_tcp", "vendor", "AirGradient");
-  MDNS.addService("http", "tcp", 80);
-  MDNS.addService("_airgradient", "tcp", 80);
-  MDNS.addServiceTxt("airgradient", "_tcp", "model", mdnsModelName);
-  MDNS.addServiceTxt("airgradient", "_tcp", "serialno", getDevId());
-  MDNS.addServiceTxt("airgradient", "_tcp", "fw_ver", ag.getVersion());
-  MDNS.addServiceTxt("airgradient", "_tcp", "vendor", "AirGradient");
+  MDNS.addService("_airgradient", "_tcp", 80);
+  MDNS.addServiceTxt("_airgradient", "_tcp", "model", mdnsModelName);
+  MDNS.addServiceTxt("_airgradient", "_tcp", "serialno", getDevId());
+  MDNS.addServiceTxt("_airgradient", "_tcp", "fw_ver", ag.getVersion());
+  MDNS.addServiceTxt("_airgradient", "_tcp", "vendor", "AirGradient");
 
   if (xTaskCreate(webServerHandler, "webserver", 1024 * 4, NULL, 5, NULL) !=
       pdTRUE) {


### PR DESCRIPTION
- Underscore before names per https://github.com/espressif/arduino-esp32/issues/962
- Only one service per port

The combination of both changes is needed to make the service discoverable in OpenHAB

The removal of the published http service is maybe something you don't want, but as long as it doesn't serve web pages it is maybe OK?