### PR TITLE
reset watchdog after sending mqtt message

### DIFF
--- a/examples/ONE/ONE.ino
+++ b/examples/ONE/ONE.ino
@@ -1235,6 +1235,7 @@ static void createMqttTask(void) {
             if (agMqtt.publish(topic.c_str(), syncData.c_str(),
                                syncData.length())) {
               Serial.println("MQTT sync success");
+              resetWatchdog();
             } else {
               Serial.println("MQTT sync failure");
             }


### PR DESCRIPTION
When disabling the serverSchedule task the ESP always resets itself after ~15 minutes.
With the additional call to resetWatchdog() in the mqtt task everything works fine.