### PR TITLE
Use capped 'val' value in displayShowDashboard()

### DIFF
--- a/examples/ONE/ONE.ino
+++ b/examples/ONE/ONE.ino
@@ -1457,7 +1457,7 @@ static void displayShowDashboard(String err) {
       if (co2Ppm < 10000) {
         val = co2Ppm;
       }
-      sprintf(strBuf, "%d", co2Ppm);
+      sprintf(strBuf, "%d", val);
     } else {
       sprintf(strBuf, "%s", "-");
     }


### PR DESCRIPTION
Fixes: e47096feac33 ("Limit show CO2 index within 4 character number (max = 9999)")