### PR TITLE
Report PM data to metrics API for AirGradient ONE

### DIFF
--- a/examples/OneOpenAir/OpenMetrics.cpp
+++ b/examples/OneOpenAir/OpenMetrics.cpp
@@ -86,6 +86,13 @@ String OpenMetrics::getPayload(void) {
         _temp = measure.Temperature;
         _hum = measure.Humidity;
       }
+
+      if (config.hasSensorPMS1) {
+        pm01 = measure.pm01_1;
+        pm25 = measure.pm25_1;
+        pm10 = measure.pm10_1;
+        pm03PCount = measure.pm03PCount_1;
+      }
     } else {
       if (config.hasSensorPMS1) {
         _temp = measure.temp_1;

--- a/examples/OneOpenAir/OpenMetrics.cpp
+++ b/examples/OneOpenAir/OpenMetrics.cpp
@@ -202,7 +202,7 @@ String OpenMetrics::getPayload(void) {
   if (_hum >= 0) {
     add_metric(
         "humidity",
-        "The relative humidity as measured by the AirGradient SHT sensor"
+        "The relative humidity as measured by the AirGradient SHT sensor",
         "gauge", "percent");
     add_metric_point("", String(_hum));
   }


### PR DESCRIPTION
I noticed that PM 0.1, 2.5, and 1.0 data on my AirGradient ONE was being reported by `/measures/current` but not `/metrcis`. This MR brings those two endpoints better into parity.

I also noticed a comma went missing causing Prometheus to no longer be able to parse the metrics. Fixed that, too.

As a side note, I notice that the logic for handling a measurement seems to be duplicated between `AgValue.cpp` and `OpenMetrics.cpp`. I suspect we'll keep seeing this kind of disparity between these endpoints until that logic is unified.