### PR TITLE
Turn off LED bar and Display if brightness is 0%, fix #114

### DIFF
--- a/examples/OneOpenAir/OneOpenAir.ino
+++ b/examples/OneOpenAir/OneOpenAir.ino
@@ -239,6 +239,9 @@ void setup() {
   if (ag->isOne()) {
     oledDisplay.setText("Warming Up", "Serial Number:", ag->deviceId().c_str());
     delay(DISPLAY_DELAY_SHOW_CONTENT_MS);
+
+    Serial.println("Display brightness: " + String(configuration.getDisplayBrightness()));
+    oledDisplay.setBrightness(configuration.getDisplayBrightness());
   }
 
   appLedHandler();
@@ -443,8 +446,14 @@ static void wdgFeedUpdate(void) {
 
 static void ledBarEnabledUpdate(void) {
   if (ag->isOne()) {
-    ag->ledBar.setBrighness(configuration.getLedBarBrightness());
-    ag->ledBar.setEnable(configuration.getLedBarMode() != LedBarModeOff);
+    int brightness = configuration.getLedBarBrightness();
+    Serial.println("LED bar brightness: " + String(brightness));
+    if ((brightness == 0) || (configuration.getLedBarMode() == LedBarModeOff)) {
+      ag->ledBar.setEnable(false);
+    } else {
+      ag->ledBar.setBrighness(brightness);
+      ag->ledBar.setEnable(configuration.getLedBarMode() != LedBarModeOff);
+    }
   }
 }
 

--- a/src/AgOledDisplay.cpp
+++ b/src/AgOledDisplay.cpp
@@ -103,7 +103,12 @@ bool OledDisplay::begin(void) {
     return false;
   }
 
-  setBrightness(config.getDisplayBrightness());
+  /** Show low brightness on startup. then it's completely turn off on main
+   * application */
+  int brightness = config.getDisplayBrightness();
+  if(brightness == 0) {
+    setBrightness(1);
+  }
 
   isBegin = true;
   logInfo("begin");
@@ -148,6 +153,10 @@ void OledDisplay::setText(String &line1, String &line2, String &line3) {
  */
 void OledDisplay::setText(const char *line1, const char *line2,
                             const char *line3) {
+  if (isDisplayOff) {
+    return;
+  }
+
   DISP()->firstPage();
   do {
     DISP()->setFont(u8g2_font_t0_16_tf);
@@ -180,6 +189,10 @@ void OledDisplay::setText(String &line1, String &line2, String &line3,
  */
 void OledDisplay::setText(const char *line1, const char *line2,
                             const char *line3, const char *line4) {
+  if (isDisplayOff) {
+    return;
+  }
+
   DISP()->firstPage();
   do {
     DISP()->setFont(u8g2_font_t0_16_tf);
@@ -201,6 +214,10 @@ void OledDisplay::showDashboard(void) { showDashboard(NULL); }
  * 
  */
 void OledDisplay::showDashboard(const char *status) {
+  if (isDisplayOff) {
+    return;
+  }
+
   char strBuf[10];
 
   DISP()->firstPage();
@@ -299,10 +316,25 @@ void OledDisplay::showDashboard(const char *status) {
 }
 
 void OledDisplay::setBrightness(int percent) {
-  DISP()->setContrast((127 * percent) / 100);
+  if (percent == 0) {
+    isDisplayOff = true;
+
+    // Clear display.
+    DISP()->firstPage();
+    do {
+    } while (DISP()->nextPage());
+
+  } else {
+    isDisplayOff = false;
+    DISP()->setContrast((127 * percent) / 100);
+  }
 }
 
 void OledDisplay::showNewFirmwareVersion(String version) {
+  if (isDisplayOff) {
+    return;
+  }
+
   DISP()->firstPage();
   do {
     DISP()->setFont(u8g2_font_t0_16_tf);
@@ -313,6 +345,10 @@ void OledDisplay::showNewFirmwareVersion(String version) {
 }
 
 void OledDisplay::showNewFirmwareUpdating(String percent) {
+  if (isDisplayOff) {
+    return;
+  }
+
   DISP()->firstPage();
   do {
     DISP()->setFont(u8g2_font_t0_16_tf);
@@ -322,6 +358,10 @@ void OledDisplay::showNewFirmwareUpdating(String percent) {
 }
 
 void OledDisplay::showNewFirmwareSuccess(String count) {
+  if (isDisplayOff) {
+    return;
+  }
+
   DISP()->firstPage();
   do {
     DISP()->setFont(u8g2_font_t0_16_tf);
@@ -332,6 +372,10 @@ void OledDisplay::showNewFirmwareSuccess(String count) {
 }
 
 void OledDisplay::showNewFirmwareFailed(void) {
+  if (isDisplayOff) {
+    return;
+  }
+
   DISP()->firstPage();
   do {
     DISP()->setFont(u8g2_font_t0_16_tf);

--- a/src/AgOledDisplay.h
+++ b/src/AgOledDisplay.h
@@ -14,6 +14,7 @@ private:
   bool isBegin = false;
   void *u8g2 = NULL;
   Measurements &value;
+  bool isDisplayOff = false;
 
   void showTempHum(bool hasStatus);
   void setCentralText(int y, String text);


### PR DESCRIPTION
The LED bar will turn off from power up after init if brightness is 0%. 

The display also keep the brightness 1% for setup and completely turn off after WiFi Connector done.