### PR TITLE
[Fix] WiFi not reset on offline mode

### DIFF
--- a/examples/OneOpenAir/OneOpenAir.ino
+++ b/examples/OneOpenAir/OneOpenAir.ino
@@ -420,6 +420,7 @@ static void factoryConfigReset(void) {
             }
 
             /** Reset WIFI */
+            WiFi.enableSTA(true);   // Incase offline mode
             WiFi.disconnect(true, true);
 
             /** Reset local config */


### PR DESCRIPTION
On offline mode the device will not perform the WiFi connection mean the WiFi STA is not enabled. On factory reset it's always failed if call `WiFi.disconnect(true, true)` to reset WiFi connection cause WiFi is not enabled. 