### PR TITLE
[Fix] Too many server GET config request

### DIFF
--- a/examples/BASIC/BASIC.ino
+++ b/examples/BASIC/BASIC.ino
@@ -41,7 +41,7 @@ CC BY-SA 4.0 Attribution-ShareAlike 4.0 International License
 #define LED_BAR_COUNT_INIT_VALUE (-1)        /** */
 #define LED_BAR_ANIMATION_PERIOD 100         /** ms */
 #define DISP_UPDATE_INTERVAL 5000            /** ms */
-#define SERVER_CONFIG_UPDATE_INTERVAL 30000  /** ms */
+#define SERVER_CONFIG_SYNC_INTERVAL 30000  /** ms */
 #define SERVER_SYNC_INTERVAL 60000           /** ms */
 #define SENSOR_CO2_CALIB_COUNTDOWN_MAX 5     /** sec */
 #define SENSOR_TVOC_UPDATE_INTERVAL 1000     /** ms */
@@ -82,7 +82,7 @@ bool hasSensorPMS = true;
 bool hasSensorSHT = true;
 int pmFailCount = 0;
 int getCO2FailCount = 0;
-AgSchedule configSchedule(SERVER_CONFIG_UPDATE_INTERVAL,
+AgSchedule configSchedule(SERVER_CONFIG_SYNC_INTERVAL,
                           updateServerConfiguration);
 AgSchedule serverSchedule(SERVER_SYNC_INTERVAL, sendDataToServer);
 AgSchedule dispSchedule(DISP_UPDATE_INTERVAL, dispHandler);

--- a/examples/BASIC/BASIC.ino
+++ b/examples/BASIC/BASIC.ino
@@ -41,7 +41,7 @@ CC BY-SA 4.0 Attribution-ShareAlike 4.0 International License
 #define LED_BAR_COUNT_INIT_VALUE (-1)        /** */
 #define LED_BAR_ANIMATION_PERIOD 100         /** ms */
 #define DISP_UPDATE_INTERVAL 5000            /** ms */
-#define SERVER_CONFIG_SYNC_INTERVAL 30000  /** ms */
+#define SERVER_CONFIG_SYNC_INTERVAL 60000    /** ms */
 #define SERVER_SYNC_INTERVAL 60000           /** ms */
 #define SENSOR_CO2_CALIB_COUNTDOWN_MAX 5     /** sec */
 #define SENSOR_TVOC_UPDATE_INTERVAL 1000     /** ms */

--- a/examples/OneOpenAir/OneOpenAir.ino
+++ b/examples/OneOpenAir/OneOpenAir.ino
@@ -55,7 +55,7 @@ CC BY-SA 4.0 Attribution-ShareAlike 4.0 International License
 
 #define LED_BAR_ANIMATION_PERIOD 100         /** ms */
 #define DISP_UPDATE_INTERVAL 2500            /** ms */
-#define SERVER_CONFIG_UPDATE_INTERVAL 15000  /** ms */
+#define SERVER_CONFIG_SYNC_INTERVAL 15000    /** ms */
 #define SERVER_SYNC_INTERVAL 60000           /** ms */
 #define MQTT_SYNC_INTERVAL 60000             /** ms */
 #define SENSOR_CO2_CALIB_COUNTDOWN_MAX 5     /** sec */
@@ -118,7 +118,7 @@ static void displayExecuteOta(OtaState state, String msg,
                               int processing);
 
 AgSchedule dispLedSchedule(DISP_UPDATE_INTERVAL, oledDisplayLedBarSchedule);
-AgSchedule configSchedule(SERVER_CONFIG_UPDATE_INTERVAL,
+AgSchedule configSchedule(SERVER_CONFIG_SYNC_INTERVAL,
                           configurationUpdateSchedule);
 AgSchedule agApiPostSchedule(SERVER_SYNC_INTERVAL, sendDataToServer);
 AgSchedule co2Schedule(SENSOR_CO2_UPDATE_INTERVAL, co2Update);

--- a/examples/OneOpenAir/OneOpenAir.ino
+++ b/examples/OneOpenAir/OneOpenAir.ino
@@ -55,7 +55,7 @@ CC BY-SA 4.0 Attribution-ShareAlike 4.0 International License
 
 #define LED_BAR_ANIMATION_PERIOD 100         /** ms */
 #define DISP_UPDATE_INTERVAL 2500            /** ms */
-#define SERVER_CONFIG_SYNC_INTERVAL 15000    /** ms */
+#define SERVER_CONFIG_SYNC_INTERVAL 60000    /** ms */
 #define SERVER_SYNC_INTERVAL 60000           /** ms */
 #define MQTT_SYNC_INTERVAL 60000             /** ms */
 #define SENSOR_CO2_CALIB_COUNTDOWN_MAX 5     /** sec */


### PR DESCRIPTION
1. Rename macro name

3. Currently the server GET configure is `15` sec for `OneOpenAir.ino` and `30` sec for `BASIC.ino` . Now set to `60` sec