### PR TITLE
`NOx` show incorrect position on display

### DIFF
--- a/src/AgOledDisplay.cpp
+++ b/src/AgOledDisplay.cpp
@@ -338,7 +338,7 @@ void OledDisplay::showDashboard(const char *status) {
       DISP()->drawStr(100, 39, strBuf);
 
       /** Draw NOx label */
-      DISP()->drawStr(85, 53, "NOx:");
+      DISP()->drawStr(100, 53, "NOx:");
       if (utils::isValidNOx(value.NOx)) {
         sprintf(strBuf, "%d", value.NOx);
       } else {


### PR DESCRIPTION
The `NOx` label show wrong position to area of PM4.5. Now move it to the area of VOC and NOx

Before
<img width="293" alt="image" src="https://github.com/user-attachments/assets/12a2cf31-d315-42bd-bb69-dd1b2d7ba326">

After
<img width="256" alt="image" src="https://github.com/user-attachments/assets/f76b671d-bca4-4a3a-a6c6-a5db4545b8e1">
