### PR TITLE
sensor value out of range

### DIFF
--- a/src/Main/utils.cpp
+++ b/src/Main/utils.cpp
@@ -12,10 +12,14 @@
 #define VALID_PMS_MIN         (0)
 #define INVALID_PMS           (-1)
 
+#define VALID_PMS03COUNT_MIN  (0)
+
 #define VALID_CO2_MAX         (10000)
 #define VALID_CO2_MIN         (0)
 #define INVALID_CO2           (-1)
 
+#define VALID_NOX_MIN         (0)
+#define VALID_VOC_MIN         (0)
 #define INVALID_NOX           (-1)
 #define INVALID_VOC           (-1)
 
@@ -24,49 +28,49 @@ utils::utils(/* args */) {}
 utils::~utils() {}
 
 bool utils::isValidTemperature(float value) {
-  if (value >= VALID_TEMPERATURE_MIN && value <= VALID_TEMPERATURE_MAX) {
+  if ((value >= VALID_TEMPERATURE_MIN) && (value <= VALID_TEMPERATURE_MAX)) {
     return true;
   }
   return false;
 }
 
 bool utils::isValidHumidity(float value) {
-  if (value >= VALID_HUMIDITY_MIN && value <= VALID_HUMIDITY_MAX) {
+  if ((value >= VALID_HUMIDITY_MIN) && (value <= VALID_HUMIDITY_MAX)) {
     return true;
   }
   return false;
 }
 
 bool utils::isValidCO2(int16_t value) {
-  if (value >= VALID_CO2_MIN && value <= VALID_CO2_MAX) {
+  if ((value >= VALID_CO2_MIN) && (value <= VALID_CO2_MAX)) {
     return true;
   }
   return false;
 }
 
 bool utils::isValidPMS(int value) {
-  if (value >= VALID_PMS_MIN && value <= VALID_PMS_MAX) {
+  if ((value >= VALID_PMS_MIN) && (value <= VALID_PMS_MAX)) {
     return true;
   }
   return false;
 }
 
 bool utils::isValidPMS03Count(int value) {
-  if (value >= 0) {
+  if (value >= VALID_PMS03COUNT_MIN) {
     return true;
   }
   return false;
 }
 
 bool utils::isValidNOx(int value) {
-  if (value > INVALID_NOX) {
+  if (value >= VALID_NOX_MIN) {
     return true;
   }
   return false;
 }
 
 bool utils::isValidVOC(int value) {
-  if (value > INVALID_VOC) {
+  if (value >= VALID_VOC_MIN) {
     return true;
   }
   return false;

--- a/src/PMS/PMS.cpp
+++ b/src/PMS/PMS.cpp
@@ -3,7 +3,7 @@
 
 /**
  * @brief Init and check that sensor has connected
- * 
+ *
  * @param stream UART stream
  * @return true Sucecss
  * @return false Failure
@@ -86,7 +86,7 @@ void PMSBase::handle() {
     case 2: {
       buf[bufIndex++] = value;
       if (bufIndex >= 4) {
-        len = toValue(&buf[2]);
+        len = toI16(&buf[2]);
         if (len != 28) {
           // Serial.printf("Got good bad len %d\r\n", len);
           len += 4;
@@ -152,98 +152,98 @@ bool PMSBase::isFailed(void) { return failed; }
  *
  * @return uint16_t
  */
-uint16_t PMSBase::getRaw0_1(void) { return toValue(&package[4]); }
+uint16_t PMSBase::getRaw0_1(void) { return toU16(&package[4]); }
 
 /**
  * @brief Read PMS 2.5 ug/m3 with CF = 1 PM estimates
  *
  * @return uint16_t
  */
-uint16_t PMSBase::getRaw2_5(void) { return toValue(&package[6]); }
+uint16_t PMSBase::getRaw2_5(void) { return toU16(&package[6]); }
 
 /**
  * @brief Read PMS 10 ug/m3 with CF = 1 PM estimates
  *
  * @return uint16_t
  */
-uint16_t PMSBase::getRaw10(void) { return toValue(&package[8]); }
+uint16_t PMSBase::getRaw10(void) { return toU16(&package[8]); }
 
 /**
  * @brief Read PMS 0.1 ug/m3
  *
  * @return uint16_t
  */
-uint16_t PMSBase::getPM0_1(void) { return toValue(&package[10]); }
+uint16_t PMSBase::getPM0_1(void) { return toU16(&package[10]); }
 
 /**
  * @brief Read PMS 2.5 ug/m3
  *
  * @return uint16_t
  */
-uint16_t PMSBase::getPM2_5(void) { return toValue(&package[12]); }
+uint16_t PMSBase::getPM2_5(void) { return toU16(&package[12]); }
 
 /**
  * @brief Read PMS 10 ug/m3
  *
  * @return uint16_t
  */
-uint16_t PMSBase::getPM10(void) { return toValue(&package[14]); }
+uint16_t PMSBase::getPM10(void) { return toU16(&package[14]); }
 
 /**
  * @brief Get numnber concentrations over 0.3 um/0.1L
  *
  * @return uint16_t
  */
-uint16_t PMSBase::getCount0_3(void) { return toValue(&package[16]); }
+uint16_t PMSBase::getCount0_3(void) { return toU16(&package[16]); }
 
 /**
  * @brief Get numnber concentrations over 0.5 um/0.1L
  *
  * @return uint16_t
  */
-uint16_t PMSBase::getCount0_5(void) { return toValue(&package[18]); }
+uint16_t PMSBase::getCount0_5(void) { return toU16(&package[18]); }
 
 /**
  * @brief Get numnber concentrations over 1.0 um/0.1L
  *
  * @return uint16_t
  */
-uint16_t PMSBase::getCount1_0(void) { return toValue(&package[20]); }
+uint16_t PMSBase::getCount1_0(void) { return toU16(&package[20]); }
 
 /**
  * @brief Get numnber concentrations over 2.5 um/0.1L
  *
  * @return uint16_t
  */
-uint16_t PMSBase::getCount2_5(void) { return toValue(&package[22]); }
+uint16_t PMSBase::getCount2_5(void) { return toU16(&package[22]); }
 
 /**
  * @brief Get numnber concentrations over 5.0 um/0.1L (only PMS5003)
  *
  * @return uint16_t
  */
-uint16_t PMSBase::getCount5_0(void) { return toValue(&package[24]); }
+uint16_t PMSBase::getCount5_0(void) { return toU16(&package[24]); }
 
 /**
  * @brief Get numnber concentrations over 10.0 um/0.1L (only PMS5003)
  *
  * @return uint16_t
  */
-uint16_t PMSBase::getCount10(void) { return toValue(&package[26]); }
+uint16_t PMSBase::getCount10(void) { return toU16(&package[26]); }
 
 /**
  * @brief Get temperature (only PMS5003T)
  *
  * @return uint16_t
  */
-uint16_t PMSBase::getTemp(void) { return toValue(&package[24]); }
+int16_t PMSBase::getTemp(void) { return toI16(&package[24]); }
 
 /**
  * @brief Get humidity (only PMS5003T)
  *
  * @return uint16_t
  */
-uint16_t PMSBase::getHum(void) { return toValue(&package[26]); }
+uint16_t PMSBase::getHum(void) { return toU16(&package[26]); }
 
 /**
  * @brief Convert PMS2.5 to US AQI unit
@@ -274,9 +274,19 @@ int PMSBase::pm25ToAQI(int pm02) {
  * @brief   Convert two byte value to uint16_t value
  *
  * @param buf bytes array (must be >= 2)
- * @return uint16_t
+ * @return int16_t
  */
-uint16_t PMSBase::toValue(char *buf) { return (buf[0] << 8) | buf[1]; }
+int16_t PMSBase::toI16(char *buf) {
+  int16_t value = buf[0];
+  value = (value << 8) | buf[1];
+  return value;
+}
+
+uint16_t PMSBase::toU16(char *buf) {
+  uint16_t value = buf[0];
+  value = (value << 8) | buf[1];
+  return value;
+}
 
 /**
  * @brief Validate package data
@@ -290,7 +300,7 @@ bool PMSBase::validate(char *buf) {
   for (int i = 0; i < 30; i++) {
     sum += buf[i];
   }
-  if (sum == toValue(&buf[30])) {
+  if (sum == toU16(&buf[30])) {
     for (int i = 0; i < 32; i++) {
       package[i] = buf[i];
     }

--- a/src/PMS/PMS.h
+++ b/src/PMS/PMS.h
@@ -24,7 +24,7 @@ public:
   uint16_t getCount10(void);
 
   /** For PMS5003T*/
-  uint16_t getTemp(void);
+  int16_t getTemp(void);
   uint16_t getHum(void);
 
   int pm25ToAQI(int pm02);
@@ -36,7 +36,8 @@ private:
   bool failed = false;
   uint32_t lastRead;
 
-  uint16_t toValue(char *buf);
+  int16_t toI16(char *buf);
+  uint16_t toU16(char* buf);
   bool validate(char *buf);
 };
 


### PR DESCRIPTION
- Add invalid value for PMS03Count
- Optimize code operator
- Fix: PMS5003T temperature has only return positive value. In case the temperature < 0 read return value is always invalid.