### PR TITLE
Add default WiFi connect

### DIFF
--- a/examples/DiyProIndoorV4_2/DiyProIndoorV4_2.ino
+++ b/examples/DiyProIndoorV4_2/DiyProIndoorV4_2.ino
@@ -328,9 +328,7 @@ static void factoryConfigReset(void) {
             // }
 
             /** Reset WIFI */
-            // WiFi.enableSTA(true); // Incase offline mode
-            // WiFi.disconnect(true, true);
-            wifiConnector.reset();
+            WiFi.disconnect(true, true);
 
             /** Reset local config */
             configuration.reset();

--- a/examples/OneOpenAir/OneOpenAir.ino
+++ b/examples/OneOpenAir/OneOpenAir.ino
@@ -424,8 +424,7 @@ static void factoryConfigReset(void) {
             }
 
             /** Reset WIFI */
-            Serial.println("Set wifi connect to 'airgradient' as default");
-            WiFi.begin("airgradient", "cleanair");
+            WiFi.disconnect(true, true);
 
             /** Reset local config */
             configuration.reset();

--- a/src/AgWiFiConnector.cpp
+++ b/src/AgWiFiConnector.cpp
@@ -41,6 +41,28 @@ bool WifiConnector::connect(void) {
     }
   }
 
+  WiFi.begin();
+  String wifiSSID = WIFI()->getWiFiSSID(true);
+  if (wifiSSID.isEmpty()) {
+    logInfo("Connected WiFi is empty, connect to default wifi \"" +
+            String(this->defaultSsid) + String("\""));
+
+    /** Set wifi connect */
+    WiFi.begin(this->defaultSsid, this->defaultPassword);
+
+    /** Wait for wifi connect to AP */
+    int count = 0;
+    while (WiFi.status() != WL_CONNECTED) {
+      delay(1000);
+      count++;
+      if (count >= 15) {
+        logError("Try connect to default wifi \"" + String(this->defaultSsid) +
+                 String("\" failed"));
+        break;
+      }
+    }
+  }
+
   WIFI()->setConfigPortalBlocking(false);
   WIFI()->setConnectTimeout(15);
   WIFI()->setTimeout(WIFI_CONNECT_COUNTDOWN_MAX);
@@ -383,3 +405,11 @@ bool WifiConnector::hasConfigurated(void) {
  * @return false
  */
 bool WifiConnector::isConfigurePorttalTimeout(void) { return connectorTimeout; }
+
+/**
+ * @brief Set wifi connect to default WiFi
+ * 
+ */
+void WifiConnector::setDefault(void) {
+  WiFi.begin("airgradient", "cleanair");
+}

--- a/src/AgWiFiConnector.h
+++ b/src/AgWiFiConnector.h
@@ -46,6 +46,10 @@ public:
   String localIpStr(void);
   bool hasConfigurated(void);
   bool isConfigurePorttalTimeout(void);
+
+  const char* defaultSsid = "airgradient";
+  const char* defaultPassword = "cleanair";
+  void setDefault(void);
 };
 
 #endif /** _AG_WIFI_CONNECTOR_H_ */


### PR DESCRIPTION
WiFi auto connect to default `airgradient` if last connection saved is empty. The WiFi connection empty after factory reset or without connect to any WiFi before