### PR TITLE
Feat/ag-client-timeout

### DIFF
--- a/src/AgApiClient.cpp
+++ b/src/AgApiClient.cpp
@@ -107,9 +107,7 @@ bool AgApiClient::postToServer(String data) {
     return false;
   }
 
-  String uri =
-      "http://hw.airgradient.com/sensors/airgradient:" + ag->deviceId() +
-      "/measures";
+  String uri = apiRoot + "/sensors/airgradient:" + ag->deviceId() + "/measures";
   // logInfo("Post uri: " + uri);
   // logInfo("Post data: " + data);
 

--- a/src/AgApiClient.cpp
+++ b/src/AgApiClient.cpp
@@ -2,6 +2,13 @@
 #include "AgConfigure.h"
 #include "AirGradient.h"
 #include "Libraries/Arduino_JSON/src/Arduino_JSON.h"
+#ifdef ESP8266
+#include <ESP8266HTTPClient.h>
+#include <ESP8266WiFi.h>
+#include <WiFiClient.h>
+#else
+#include <HTTPClient.h>
+#endif
 
 AgApiClient::AgApiClient(Stream &debug, Configuration &config)
     : PrintLog(debug, "ApiClient"), config(config) {}
@@ -51,7 +58,7 @@ bool AgApiClient::fetchServerConfiguration(void) {
   }
 #else
   HTTPClient client;
-  _setHttpClientTimeout(&client);
+  client.setTimeout(timeoutMs);
   if (client.begin(uri) == false) {
     getConfigFailed = true;
     return false;
@@ -113,7 +120,7 @@ bool AgApiClient::postToServer(String data) {
 
   WiFiClient wifiClient;
   HTTPClient client;
-  _setHttpClientTimeout(&client);
+  client.setTimeout(timeoutMs);
   if (client.begin(wifiClient, uri.c_str()) == false) {
     logError("Init client failed");
     return false;
@@ -191,13 +198,4 @@ void AgApiClient::setApiRoot(const String &apiRoot) { this->apiRoot = apiRoot; }
  */
 void AgApiClient::setTimeout(uint16_t timeoutMs) {
   this->timeoutMs = timeoutMs;
-}
-
-/**
- * @brief Set timeout to both connect to server and tcp connection timeout
- *
- */
-void AgApiClient::_setHttpClientTimeout(HTTPClient *httpClient) {
-  httpClient->setTimeout(timeoutMs);
-  httpClient->setConnectTimeout(timeoutMs);
 }

--- a/src/AgApiClient.cpp
+++ b/src/AgApiClient.cpp
@@ -185,6 +185,15 @@ String AgApiClient::getApiRoot() const { return apiRoot; }
 void AgApiClient::setApiRoot(const String &apiRoot) { this->apiRoot = apiRoot; }
 
 /**
+ * @brief Set http request timeout. (Default: 10s)
+ *
+ * @param timeoutMs
+ */
+void AgApiClient::setTimeout(uint16_t timeoutMs) {
+  this->timeoutMs = timeoutMs;
+}
+
+/**
  * @brief Set timeout to both connect to server and tcp connection timeout
  *
  */

--- a/src/AgApiClient.cpp
+++ b/src/AgApiClient.cpp
@@ -2,13 +2,6 @@
 #include "AgConfigure.h"
 #include "AirGradient.h"
 #include "Libraries/Arduino_JSON/src/Arduino_JSON.h"
-#ifdef ESP8266
-#include <ESP8266HTTPClient.h>
-#include <ESP8266WiFi.h>
-#include <WiFiClient.h>
-#else
-#include <HTTPClient.h>
-#endif
 
 AgApiClient::AgApiClient(Stream &debug, Configuration &config)
     : PrintLog(debug, "ApiClient"), config(config) {}
@@ -58,6 +51,7 @@ bool AgApiClient::fetchServerConfiguration(void) {
   }
 #else
   HTTPClient client;
+  _setHttpClientTimeout(&client);
   if (client.begin(uri) == false) {
     getConfigFailed = true;
     return false;
@@ -121,6 +115,7 @@ bool AgApiClient::postToServer(String data) {
 
   WiFiClient wifiClient;
   HTTPClient client;
+  _setHttpClientTimeout(&client);
   if (client.begin(wifiClient, uri.c_str()) == false) {
     logError("Init client failed");
     return false;
@@ -190,3 +185,12 @@ bool AgApiClient::sendPing(int rssi, int bootCount) {
 String AgApiClient::getApiRoot() const { return apiRoot; }
 
 void AgApiClient::setApiRoot(const String &apiRoot) { this->apiRoot = apiRoot; }
+
+/**
+ * @brief Set timeout to both connect to server and tcp connection timeout
+ *
+ */
+void AgApiClient::_setHttpClientTimeout(HTTPClient *httpClient) {
+  httpClient->setTimeout(timeoutMs);
+  httpClient->setConnectTimeout(timeoutMs);
+}

--- a/src/AgApiClient.h
+++ b/src/AgApiClient.h
@@ -16,6 +16,14 @@
 #include "Main/PrintLog.h"
 #include <Arduino.h>
 
+#ifdef ESP8266
+#include <ESP8266HTTPClient.h>
+#include <ESP8266WiFi.h>
+#include <WiFiClient.h>
+#else
+#include <HTTPClient.h>
+#endif
+
 class AgApiClient : public PrintLog {
 private:
   Configuration &config;
@@ -25,6 +33,9 @@ private:
   bool getConfigFailed;
   bool postToServerFailed;
   bool notAvailableOnDashboard = false; // Device not setup on Airgradient cloud dashboard.
+  uint16_t timeoutMs = 10000;           // Default set to 10s
+
+  void _setHttpClientTimeout(HTTPClient *httpClient);
 
 public:
   AgApiClient(Stream &stream, Configuration &config);

--- a/src/AgApiClient.h
+++ b/src/AgApiClient.h
@@ -51,6 +51,7 @@ public:
   bool sendPing(int rssi, int bootCount);
   String getApiRoot() const;
   void setApiRoot(const String &apiRoot);
+  void setTimeout(uint16_t timeoutMs);
 };
 
 #endif /** _AG_API_CLIENT_H_ */

--- a/src/AgApiClient.h
+++ b/src/AgApiClient.h
@@ -16,14 +16,6 @@
 #include "Main/PrintLog.h"
 #include <Arduino.h>
 
-#ifdef ESP8266
-#include <ESP8266HTTPClient.h>
-#include <ESP8266WiFi.h>
-#include <WiFiClient.h>
-#else
-#include <HTTPClient.h>
-#endif
-
 class AgApiClient : public PrintLog {
 private:
   Configuration &config;
@@ -34,8 +26,6 @@ private:
   bool postToServerFailed;
   bool notAvailableOnDashboard = false; // Device not setup on Airgradient cloud dashboard.
   uint16_t timeoutMs = 10000;           // Default set to 10s
-
-  void _setHttpClientTimeout(HTTPClient *httpClient);
 
 public:
   AgApiClient(Stream &stream, Configuration &config);


### PR DESCRIPTION
## Updates

1. Set default http request timeout to 10s on `AgApiClient` class
2. New `AgApiClient` member to set http request timeout from the caller
3. [Fix](https://github.com/airgradienthq/arduino/blob/master/src/AgApiClient.cpp#L116) `AgApiClient::postToServer` uri formatting not using `apiRoot`