### PR TITLE
Add log: PMS5003x sensor print log firmware version

### DIFF
--- a/examples/BASIC/BASIC.ino
+++ b/examples/BASIC/BASIC.ino
@@ -513,6 +513,7 @@ static void updatePm(void) {
     Serial.printf("PM2.5 ug/m3: %d\r\n", measurements.pm25_1);
     Serial.printf("PM10 ug/m3: %d\r\n", measurements.pm10_1);
     Serial.printf("PM0.3 Count: %d\r\n", measurements.pm03PCount_1);
+    Serial.printf("PM firmware version: %d\r\n", ag.pms5003.getFirmwareVersion());
     ag.pms5003.resetFailCount();
   } else {
     ag.pms5003.updateFailCount();

--- a/examples/DiyProIndoorV3_3/DiyProIndoorV3_3.ino
+++ b/examples/DiyProIndoorV3_3/DiyProIndoorV3_3.ino
@@ -565,6 +565,7 @@ static void updatePm(void) {
     Serial.printf("PM2.5 ug/m3: %d\r\n", measurements.pm25_1);
     Serial.printf("PM10 ug/m3: %d\r\n", measurements.pm10_1);
     Serial.printf("PM0.3 Count: %d\r\n", measurements.pm03PCount_1);
+    Serial.printf("PM firmware version: %d\r\n", ag.pms5003.getFirmwareVersion());
     ag.pms5003.resetFailCount();
   } else {
     ag.pms5003.updateFailCount();

--- a/examples/DiyProIndoorV4_2/DiyProIndoorV4_2.ino
+++ b/examples/DiyProIndoorV4_2/DiyProIndoorV4_2.ino
@@ -606,6 +606,7 @@ static void updatePm(void) {
     Serial.printf("PM2.5 ug/m3: %d\r\n", measurements.pm25_1);
     Serial.printf("PM10 ug/m3: %d\r\n", measurements.pm10_1);
     Serial.printf("PM0.3 Count: %d\r\n", measurements.pm03PCount_1);
+    Serial.printf("PM firmware version: %d\r\n", ag.pms5003.getFirmwareVersion());
     ag.pms5003.resetFailCount();
   } else {
     ag.pms5003.updateFailCount();

--- a/examples/OneOpenAir/OneOpenAir.ino
+++ b/examples/OneOpenAir/OneOpenAir.ino
@@ -1020,10 +1020,11 @@ static void updatePm(void) {
       Serial.printf("PM2.5 ug/m3: %d\r\n", measurements.pm25_1);
       Serial.printf("PM10 ug/m3: %d\r\n", measurements.pm10_1);
       Serial.printf("PM0.3 Count: %d\r\n", measurements.pm03PCount_1);
+      Serial.printf("PM firmware version: %d\r\n", ag->pms5003.getFirmwareVersion());
       ag->pms5003.resetFailCount();
     } else {
       ag->pms5003.updateFailCount();
-      Serial.printf("PMS read faile %d times\r\n", ag->pms5003.getFailCount());
+      Serial.printf("PMS read failed %d times\r\n", ag->pms5003.getFailCount());
       if (ag->pms5003.getFailCount() >= PMS_FAIL_COUNT_SET_INVALID) {
         measurements.pm01_1 = utils::getInvalidPmValue();
         measurements.pm25_1 = utils::getInvalidPmValue();
@@ -1059,6 +1060,7 @@ static void updatePm(void) {
                     ag->pms5003t_1.compensateTemp(measurements.temp_1));
       Serial.printf("[1] Relative Humidity compensated: %0.2f\r\n",
                     ag->pms5003t_1.compensateHum(measurements.hum_1));
+      Serial.printf("[1] PM firmware version: %d\r\n", ag->pms5003t_1.getFirmwareVersion());
 
       ag->pms5003t_1.resetFailCount();
     } else {
@@ -1102,6 +1104,7 @@ static void updatePm(void) {
                     ag->pms5003t_1.compensateTemp(measurements.temp_2));
       Serial.printf("[2] Relative Humidity compensated: %0.2f\r\n",
                     ag->pms5003t_1.compensateHum(measurements.hum_2));
+      Serial.printf("[2] PM firmware version: %d\r\n", ag->pms5003t_2.getFirmwareVersion());
 
       ag->pms5003t_2.resetFailCount();
     } else {


### PR DESCRIPTION
PM sensor log firmware version along side with PM value: `PM firmware version: 151`
```10:35:43.206 > PM1 ug/m3: 11
10:35:43.207 > PM2.5 ug/m3: 23
10:35:43.207 > PM10 ug/m3: 27
10:35:43.207 > PM0.3 Count: 2169
10:35:43.207 > PM firmware version: 151
10:35:43.494 > Temperature in C: 26.79
10:35:43.494 > Relative Humidity: 82
10:35:43.494 > Temperature compensated in C: 26.79
10:35:43.494 > Relative Humidity compensated: 82
```