### PR TITLE
Added support clearing display at 0 brightness for DIY Boards

### DIFF
--- a/src/AgOledDisplay.cpp
+++ b/src/AgOledDisplay.cpp
@@ -424,7 +424,17 @@ void OledDisplay::setBrightness(int percent) {
       DISP()->setContrast((127 * percent) / 100);
     }
   } else if (ag->isBasic()) {
-    ag->display.setContrast((255 * percent) / 100);
+    if (percent == 0) {
+      isDisplayOff = true;
+
+      // Clear display.
+      ag->display.clear();
+      ag->display.show();
+    }
+    else {
+      isDisplayOff = false;
+      ag->display.setContrast((255 * percent) / 100);
+    }
   }
 }
 


### PR DESCRIPTION
Heya!

Currently, the only affect the brightness setting has with the DIY boards is an attempt to set the contrast. 
Setting the contrast to 0 does not have any effect.  This appears to be a known limitation for these display boards.
Instead clearing the display buffer and calling show to display a blank screen.

Personal quality of life feature that I've been using that I figured I would attempt to add. 

Assuming this repo welcome contributions, if not let me know!

Thanks in advance!