### PR TITLE
Fix showing "Server N/A" when postDataToAirGradient is false

### DIFF
--- a/src/AgStateMachine.cpp
+++ b/src/AgStateMachine.cpp
@@ -495,7 +495,7 @@ void StateMachine::displayHandle(AgStateMachineState state) {
     break;
   }
   case AgStateMachineServerLost: {
-    disp.showDashboard("Server N/A");
+    disp.showDashboard("AG Server N/A");
     break;
   }
   case AgStateMachineSensorConfigFailed: {
@@ -504,7 +504,7 @@ void StateMachine::displayHandle(AgStateMachineState state) {
       if (ms >= 5000) {
         addToDashboardTime = millis();
         if (addToDashBoardToggle) {
-          disp.showDashboard("Add to Dashboard");
+          disp.showDashboard("Add to AG Dashb.");
         } else {
           disp.showDashboard(ag->deviceId().c_str());
         }


### PR DESCRIPTION
## Changes

1. Fix showing `server N/A` when `postDataToAirGradient` is set to `False`. This case occur when `postDataToAirGradient` set to `false` locally while previously device is failed to post data to server. The status stayed on the display.
2. Merge update network related status error for led bar and oled display in 1 function.