### PR TITLE
Restructure Measurements class

### DIFF
--- a/examples/BASIC/BASIC.ino
+++ b/examples/BASIC/BASIC.ino
@@ -49,9 +49,8 @@ CC BY-SA 4.0 Attribution-ShareAlike 4.0 International License
 #define SENSOR_TVOC_UPDATE_INTERVAL 1000              /** ms */
 #define SENSOR_CO2_UPDATE_INTERVAL 4000               /** ms */
 #define SENSOR_PM_UPDATE_INTERVAL 2000                /** ms */
-#define SENSOR_TEMP_HUM_UPDATE_INTERVAL 2000          /** ms */
+#define SENSOR_TEMP_HUM_UPDATE_INTERVAL 6000          /** ms */
 #define DISPLAY_DELAY_SHOW_CONTENT_MS 2000            /** ms */
-#define FIRMWARE_CHECK_FOR_UPDATE_MS (60 * 60 * 1000) /** ms */
 
 static AirGradient ag(DIY_BASIC);
 static Configuration configuration(Serial);
@@ -68,7 +67,6 @@ static LocalServer localServer(Serial, openMetrics, measurements, configuration,
                                wifiConnector);
 static MqttClient mqttClient(Serial);
 
-static int getCO2FailCount = 0;
 static AgFirmwareMode fwMode = FW_MODE_I_BASIC_40PS;
 
 static String fwNewVersion;
@@ -90,6 +88,8 @@ static void wdgFeedUpdate(void);
 static bool sgp41Init(void);
 static void wifiFactoryConfigure(void);
 static void mqttHandle(void);
+static int calculateMaxPeriod(int updateInterval);
+static void setMeasurementMaxPeriod();
 
 AgSchedule dispLedSchedule(DISP_UPDATE_INTERVAL, oledDisplaySchedule);
 AgSchedule configSchedule(SERVER_CONFIG_SYNC_INTERVAL,
@@ -130,6 +130,10 @@ void setup() {
 
   /** Init sensor */
   boardInit();
+  setMeasurementMaxPeriod();
+
+  // Uncomment below line to print every measurements reading update
+  // measurements.setDebug(true);
 
   /** Connecting wifi */
   bool connectToWifi = false;
@@ -230,17 +234,16 @@ void loop() {
 }
 
 static void co2Update(void) {
+  if (!configuration.hasSensorS8) {
+    // Device don't have S8 sensor
+    return;
+  }
+
   int value = ag.s8.getCo2();
   if (utils::isValidCO2(value)) {
-    measurements.CO2 = value;
-    getCO2FailCount = 0;
-    Serial.printf("CO2 (ppm): %d\r\n", measurements.CO2);
+    measurements.update(Measurements::CO2, value);
   } else {
-    getCO2FailCount++;
-    Serial.printf("Get CO2 failed: %d\r\n", getCO2FailCount);
-    if (getCO2FailCount >= 3) {
-      measurements.CO2 = utils::getInvalidCO2();
-    }
+    measurements.update(Measurements::CO2, utils::getInvalidCO2());
   }
 }
 
@@ -313,8 +316,7 @@ static void mqttHandle(void) {
   }
 
   if (mqttClient.isConnected()) {
-    String payload = measurements.toString(true, fwMode, wifiConnector.RSSI(),
-                                           &ag, &configuration);
+    String payload = measurements.toString(true, fwMode, wifiConnector.RSSI(), ag, configuration);
     String topic = "airgradient/readings/" + ag.deviceId();
     if (mqttClient.publish(topic.c_str(), payload.c_str(), payload.length())) {
       Serial.println("MQTT sync success");
@@ -490,46 +492,27 @@ static void oledDisplaySchedule(void) {
 }
 
 static void updateTvoc(void) {
-  measurements.TVOC = ag.sgp41.getTvocIndex();
-  measurements.TVOCRaw = ag.sgp41.getTvocRaw();
-  measurements.NOx = ag.sgp41.getNoxIndex();
-  measurements.NOxRaw = ag.sgp41.getNoxRaw();
+  if (!configuration.hasSensorSGP) {
+    return;
+  }
 
-  Serial.println();
-  Serial.printf("TVOC index: %d\r\n", measurements.TVOC);
-  Serial.printf("TVOC raw: %d\r\n", measurements.TVOCRaw);
-  Serial.printf("NOx index: %d\r\n", measurements.NOx);
-  Serial.printf("NOx raw: %d\r\n", measurements.NOxRaw);
+  measurements.update(Measurements::TVOC, ag.sgp41.getTvocIndex());
+  measurements.update(Measurements::TVOCRaw, ag.sgp41.getTvocRaw());
+  measurements.update(Measurements::NOx, ag.sgp41.getNoxIndex());
+  measurements.update(Measurements::NOxRaw, ag.sgp41.getNoxRaw());
 }
 
 static void updatePm(void) {
   if (ag.pms5003.connected()) {
-    measurements.pm01_1 = ag.pms5003.getPm01Ae();
-    measurements.pm25_1 = ag.pms5003.getPm25Ae();
-    measurements.pm10_1 = ag.pms5003.getPm10Ae();
-    measurements.pm03PCount_1 = ag.pms5003.getPm03ParticleCount();
-
-    Serial.println();
-    Serial.printf("PM1 ug/m3: %d\r\n", measurements.pm01_1);
-    Serial.printf("PM2.5 ug/m3: %d\r\n", measurements.pm25_1);
-    Serial.printf("PM10 ug/m3: %d\r\n", measurements.pm10_1);
-    Serial.printf("PM0.3 Count: %d\r\n", measurements.pm03PCount_1);
-    Serial.printf("PM firmware version: %d\r\n", ag.pms5003.getFirmwareVersion());
-    ag.pms5003.resetFailCount();
+    measurements.update(Measurements::PM01, ag.pms5003.getPm01Ae());
+    measurements.update(Measurements::PM25, ag.pms5003.getPm25Ae());
+    measurements.update(Measurements::PM10, ag.pms5003.getPm10Ae());
+    measurements.update(Measurements::PM03_PC, ag.pms5003.getPm03ParticleCount());
   } else {
-    ag.pms5003.updateFailCount();
-    Serial.printf("PMS read failed %d times\r\n", ag.pms5003.getFailCount());
-    if (ag.pms5003.getFailCount() >= PMS_FAIL_COUNT_SET_INVALID) {
-      measurements.pm01_1 = utils::getInvalidPmValue();
-      measurements.pm25_1 = utils::getInvalidPmValue();
-      measurements.pm10_1 = utils::getInvalidPmValue();
-      measurements.pm03PCount_1 = utils::getInvalidPmValue();
-    }
-
-    if(ag.pms5003.getFailCount() >= ag.pms5003.getFailCountMax()) {
-      Serial.printf("PMS failure count reach to max set %d, restarting...", ag.pms5003.getFailCountMax());
-      ESP.restart();
-    }
+    measurements.update(Measurements::PM01, utils::getInvalidPmValue());
+    measurements.update(Measurements::PM25, utils::getInvalidPmValue());
+    measurements.update(Measurements::PM10, utils::getInvalidPmValue());
+    measurements.update(Measurements::PM03_PC, utils::getInvalidPmValue());
   }
 }
 
@@ -540,8 +523,7 @@ static void sendDataToServer(void) {
     return;
   }
 
-  String syncData = measurements.toString(false, fwMode, wifiConnector.RSSI(),
-                                          &ag, &configuration);
+  String syncData = measurements.toString(false, fwMode, wifiConnector.RSSI(), ag, configuration);
   if (apiClient.postToServer(syncData)) {
     Serial.println();
     Serial.println(
@@ -552,26 +534,54 @@ static void sendDataToServer(void) {
 }
 
 static void tempHumUpdate(void) {
-  delay(100);
   if (ag.sht.measure()) {
-    measurements.Temperature = ag.sht.getTemperature();
-    measurements.Humidity = ag.sht.getRelativeHumidity();
+    float temp = ag.sht.getTemperature();
+    float rhum = ag.sht.getRelativeHumidity();
 
-    Serial.printf("Temperature in C: %0.2f\r\n", measurements.Temperature);
-    Serial.printf("Relative Humidity: %d\r\n", measurements.Humidity);
-    Serial.printf("Temperature compensated in C: %0.2f\r\n",
-                  measurements.Temperature);
-    Serial.printf("Relative Humidity compensated: %d\r\n",
-                  measurements.Humidity);
+    measurements.update(Measurements::Temperature, temp);
+    measurements.update(Measurements::Humidity, rhum);
 
     // Update compensation temperature and humidity for SGP41
     if (configuration.hasSensorSGP) {
-      ag.sgp41.setCompensationTemperatureHumidity(measurements.Temperature,
-                                                  measurements.Humidity);
+      ag.sgp41.setCompensationTemperatureHumidity(temp, rhum);
     }
   } else {
+    measurements.update(Measurements::Temperature, utils::getInvalidTemperature());
+    measurements.update(Measurements::Humidity, utils::getInvalidHumidity());
     Serial.println("SHT read failed");
-    measurements.Temperature = utils::getInvalidTemperature();
-    measurements.Humidity = utils::getInvalidHumidity();
   }
+}
+
+/* Set max period for each measurement type based on sensor update interval*/
+void setMeasurementMaxPeriod() {
+  /// Max period for S8 sensors measurements
+  measurements.maxPeriod(Measurements::CO2, calculateMaxPeriod(SENSOR_CO2_UPDATE_INTERVAL));
+  /// Max period for SGP sensors measurements
+  measurements.maxPeriod(Measurements::TVOC, calculateMaxPeriod(SENSOR_TVOC_UPDATE_INTERVAL));
+  measurements.maxPeriod(Measurements::TVOCRaw, calculateMaxPeriod(SENSOR_TVOC_UPDATE_INTERVAL));
+  measurements.maxPeriod(Measurements::NOx, calculateMaxPeriod(SENSOR_TVOC_UPDATE_INTERVAL));
+  measurements.maxPeriod(Measurements::NOxRaw, calculateMaxPeriod(SENSOR_TVOC_UPDATE_INTERVAL));
+  /// Max period for PMS sensors measurements
+  measurements.maxPeriod(Measurements::PM25, calculateMaxPeriod(SENSOR_PM_UPDATE_INTERVAL));
+  measurements.maxPeriod(Measurements::PM01, calculateMaxPeriod(SENSOR_PM_UPDATE_INTERVAL));
+  measurements.maxPeriod(Measurements::PM10, calculateMaxPeriod(SENSOR_PM_UPDATE_INTERVAL));
+  measurements.maxPeriod(Measurements::PM03_PC, calculateMaxPeriod(SENSOR_PM_UPDATE_INTERVAL));
+  // Temperature and Humidity
+  if (configuration.hasSensorSHT) {
+    /// Max period for SHT sensors measurements
+    measurements.maxPeriod(Measurements::Temperature,
+                           calculateMaxPeriod(SENSOR_TEMP_HUM_UPDATE_INTERVAL));
+    measurements.maxPeriod(Measurements::Humidity,
+                           calculateMaxPeriod(SENSOR_TEMP_HUM_UPDATE_INTERVAL));
+  } else {
+    /// Temp and hum data retrieved from PMS5003T sensor
+    measurements.maxPeriod(Measurements::Temperature,
+                           calculateMaxPeriod(SENSOR_PM_UPDATE_INTERVAL));
+    measurements.maxPeriod(Measurements::Humidity, calculateMaxPeriod(SENSOR_PM_UPDATE_INTERVAL));
+  }
+}
+
+int calculateMaxPeriod(int updateInterval) {
+  // 0.5 is 50% reduced interval for max period
+  return (SERVER_SYNC_INTERVAL - (SERVER_SYNC_INTERVAL * 0.5)) / updateInterval;
 }

--- a/examples/BASIC/LocalServer.cpp
+++ b/examples/BASIC/LocalServer.cpp
@@ -53,9 +53,8 @@ void LocalServer::_GET_metrics(void) {
 }
 
 void LocalServer::_GET_measure(void) {
-  server.send(
-      200, "application/json",
-      measure.toString(true, fwMode, wifiConnector.RSSI(), ag, &config));
+  String toSend = measure.toString(true, fwMode, wifiConnector.RSSI(), *ag, config);
+  server.send(200, "application/json", toSend);
 }
 
 void LocalServer::setFwMode(AgFirmwareMode fwMode) { this->fwMode = fwMode; }

--- a/examples/BASIC/OpenMetrics.cpp
+++ b/examples/BASIC/OpenMetrics.cpp
@@ -73,19 +73,30 @@ String OpenMetrics::getPayload(void) {
   int pm03PCount = utils::getInvalidPmValue();
   int atmpCompensated = utils::getInvalidTemperature();
   int ahumCompensated = utils::getInvalidHumidity();
+  int tvoc = utils::getInvalidVOC();
+  int tvoc_raw = utils::getInvalidVOC();
+  int nox = utils::getInvalidNOx();
+  int nox_raw = utils::getInvalidNOx();
 
   if (config.hasSensorSHT) {
-    _temp = measure.Temperature;
-    _hum = measure.Humidity;
+    _temp = measure.getFloat(Measurements::Temperature);
+    _hum = measure.getFloat(Measurements::Humidity);
     atmpCompensated = _temp;
     ahumCompensated = _hum;
   }
 
   if (config.hasSensorPMS1) {
-    pm01 = measure.pm01_1;
-    pm25 = measure.pm25_1;
-    pm10 = measure.pm10_1;
-    pm03PCount = measure.pm03PCount_1;
+    pm01 = measure.get(Measurements::PM01);
+    pm25 = measure.get(Measurements::PM25);
+    pm10 = measure.get(Measurements::PM10);
+    pm03PCount = measure.get(Measurements::PM03_PC);
+  }
+
+  if (config.hasSensorSGP) {
+    tvoc = measure.get(Measurements::TVOC);
+    tvoc_raw = measure.get(Measurements::TVOCRaw);
+    nox = measure.get(Measurements::NOx);
+    nox_raw = measure.get(Measurements::NOxRaw);
   }
 
   if (config.hasSensorPMS1) {
@@ -120,33 +131,33 @@ String OpenMetrics::getPayload(void) {
   }
 
   if (config.hasSensorSGP) {
-    if (utils::isValidVOC(measure.TVOC)) {
+    if (utils::isValidVOC(tvoc)) {
       add_metric("tvoc_index",
                  "The processed Total Volatile Organic Compounds (TVOC) index "
                  "as measured by the AirGradient SGP sensor",
                  "gauge");
-      add_metric_point("", String(measure.TVOC));
+      add_metric_point("", String(tvoc));
     }
-    if (utils::isValidVOC(measure.TVOCRaw)) {
+    if (utils::isValidVOC(tvoc_raw)) {
       add_metric("tvoc_raw",
                  "The raw input value to the Total Volatile Organic Compounds "
                  "(TVOC) index as measured by the AirGradient SGP sensor",
                  "gauge");
-      add_metric_point("", String(measure.TVOCRaw));
+      add_metric_point("", String(tvoc_raw));
     }
-    if (utils::isValidNOx(measure.NOx)) {
+    if (utils::isValidNOx(nox)) {
       add_metric("nox_index",
                  "The processed Nitrous Oxide (NOx) index as measured by the "
                  "AirGradient SGP sensor",
                  "gauge");
-      add_metric_point("", String(measure.NOx));
+      add_metric_point("", String(nox));
     }
-    if (utils::isValidNOx(measure.NOxRaw)) {
+    if (utils::isValidNOx(nox_raw)) {
       add_metric("nox_raw",
                  "The raw input value to the Nitrous Oxide (NOx) index as "
                  "measured by the AirGradient SGP sensor",
                  "gauge");
-      add_metric_point("", String(measure.NOxRaw));
+      add_metric_point("", String(nox_raw));
     }
   }
 

--- a/examples/DiyProIndoorV3_3/DiyProIndoorV3_3.ino
+++ b/examples/DiyProIndoorV3_3/DiyProIndoorV3_3.ino
@@ -49,9 +49,8 @@ CC BY-SA 4.0 Attribution-ShareAlike 4.0 International License
 #define SENSOR_TVOC_UPDATE_INTERVAL 1000              /** ms */
 #define SENSOR_CO2_UPDATE_INTERVAL 4000               /** ms */
 #define SENSOR_PM_UPDATE_INTERVAL 2000                /** ms */
-#define SENSOR_TEMP_HUM_UPDATE_INTERVAL 2000          /** ms */
+#define SENSOR_TEMP_HUM_UPDATE_INTERVAL 6000          /** ms */
 #define DISPLAY_DELAY_SHOW_CONTENT_MS 2000            /** ms */
-#define FIRMWARE_CHECK_FOR_UPDATE_MS (60 * 60 * 1000) /** ms */
 
 static AirGradient ag(DIY_PRO_INDOOR_V3_3);
 static Configuration configuration(Serial);
@@ -68,7 +67,6 @@ static LocalServer localServer(Serial, openMetrics, measurements, configuration,
                                wifiConnector);
 static MqttClient mqttClient(Serial);
 
-static int getCO2FailCount = 0;
 static AgFirmwareMode fwMode = FW_MODE_I_33PS;
 
 static String fwNewVersion;
@@ -90,6 +88,8 @@ static void wdgFeedUpdate(void);
 static bool sgp41Init(void);
 static void wifiFactoryConfigure(void);
 static void mqttHandle(void);
+static int calculateMaxPeriod(int updateInterval);
+static void setMeasurementMaxPeriod();
 
 AgSchedule dispLedSchedule(DISP_UPDATE_INTERVAL, oledDisplaySchedule);
 AgSchedule configSchedule(SERVER_CONFIG_SYNC_INTERVAL,
@@ -130,6 +130,10 @@ void setup() {
 
   /** Init sensor */
   boardInit();
+  setMeasurementMaxPeriod();
+
+  // Uncomment below line to print every measurements reading update
+  // measurements.setDebug(true);
 
   /** Connecting wifi */
   bool connectToWifi = false;
@@ -228,17 +232,16 @@ void loop() {
 }
 
 static void co2Update(void) {
+  if (!configuration.hasSensorS8) {
+    // Device don't have S8 sensor
+    return;
+  }
+
   int value = ag.s8.getCo2();
   if (utils::isValidCO2(value)) {
-    measurements.CO2 = value;
-    getCO2FailCount = 0;
-    Serial.printf("CO2 (ppm): %d\r\n", measurements.CO2);
+    measurements.update(Measurements::CO2, value);
   } else {
-    getCO2FailCount++;
-    Serial.printf("Get CO2 failed: %d\r\n", getCO2FailCount);
-    if (getCO2FailCount >= 3) {
-      measurements.CO2 = utils::getInvalidCO2();
-    }
+    measurements.update(Measurements::CO2, utils::getInvalidCO2());
   }
 }
 
@@ -370,8 +373,7 @@ static void mqttHandle(void) {
   }
 
   if (mqttClient.isConnected()) {
-    String payload = measurements.toString(true, fwMode, wifiConnector.RSSI(),
-                                           &ag, &configuration);
+    String payload = measurements.toString(true, fwMode, wifiConnector.RSSI(), ag, configuration);
     String topic = "airgradient/readings/" + ag.deviceId();
     if (mqttClient.publish(topic.c_str(), payload.c_str(), payload.length())) {
       Serial.println("MQTT sync success");
@@ -542,46 +544,27 @@ static void oledDisplaySchedule(void) {
 }
 
 static void updateTvoc(void) {
-  measurements.TVOC = ag.sgp41.getTvocIndex();
-  measurements.TVOCRaw = ag.sgp41.getTvocRaw();
-  measurements.NOx = ag.sgp41.getNoxIndex();
-  measurements.NOxRaw = ag.sgp41.getNoxRaw();
+  if (!configuration.hasSensorSGP) {
+    return;
+  }
 
-  Serial.println();
-  Serial.printf("TVOC index: %d\r\n", measurements.TVOC);
-  Serial.printf("TVOC raw: %d\r\n", measurements.TVOCRaw);
-  Serial.printf("NOx index: %d\r\n", measurements.NOx);
-  Serial.printf("NOx raw: %d\r\n", measurements.NOxRaw);
+  measurements.update(Measurements::TVOC, ag.sgp41.getTvocIndex());
+  measurements.update(Measurements::TVOCRaw, ag.sgp41.getTvocRaw());
+  measurements.update(Measurements::NOx, ag.sgp41.getNoxIndex());
+  measurements.update(Measurements::NOxRaw, ag.sgp41.getNoxRaw());
 }
 
 static void updatePm(void) {
   if (ag.pms5003.connected()) {
-    measurements.pm01_1 = ag.pms5003.getPm01Ae();
-    measurements.pm25_1 = ag.pms5003.getPm25Ae();
-    measurements.pm10_1 = ag.pms5003.getPm10Ae();
-    measurements.pm03PCount_1 = ag.pms5003.getPm03ParticleCount();
-
-    Serial.println();
-    Serial.printf("PM1 ug/m3: %d\r\n", measurements.pm01_1);
-    Serial.printf("PM2.5 ug/m3: %d\r\n", measurements.pm25_1);
-    Serial.printf("PM10 ug/m3: %d\r\n", measurements.pm10_1);
-    Serial.printf("PM0.3 Count: %d\r\n", measurements.pm03PCount_1);
-    Serial.printf("PM firmware version: %d\r\n", ag.pms5003.getFirmwareVersion());
-    ag.pms5003.resetFailCount();
+    measurements.update(Measurements::PM01, ag.pms5003.getPm01Ae());
+    measurements.update(Measurements::PM25, ag.pms5003.getPm25Ae());
+    measurements.update(Measurements::PM10, ag.pms5003.getPm10Ae());
+    measurements.update(Measurements::PM03_PC, ag.pms5003.getPm03ParticleCount());
   } else {
-    ag.pms5003.updateFailCount();
-    Serial.printf("PMS read failed %d times\r\n", ag.pms5003.getFailCount());
-    if (ag.pms5003.getFailCount() >= PMS_FAIL_COUNT_SET_INVALID) {
-      measurements.pm01_1 = utils::getInvalidPmValue();
-      measurements.pm25_1 = utils::getInvalidPmValue();
-      measurements.pm10_1 = utils::getInvalidPmValue();
-      measurements.pm03PCount_1 = utils::getInvalidPmValue();
-    }
-
-    if(ag.pms5003.getFailCount() >= ag.pms5003.getFailCountMax()) {
-      Serial.printf("PMS failure count reach to max set %d, restarting...", ag.pms5003.getFailCountMax());
-      ESP.restart();
-    }
+    measurements.update(Measurements::PM01, utils::getInvalidPmValue());
+    measurements.update(Measurements::PM25, utils::getInvalidPmValue());
+    measurements.update(Measurements::PM10, utils::getInvalidPmValue());
+    measurements.update(Measurements::PM03_PC, utils::getInvalidPmValue());
   }
 }
 
@@ -592,8 +575,7 @@ static void sendDataToServer(void) {
     return;
   }
 
-  String syncData = measurements.toString(false, fwMode, wifiConnector.RSSI(),
-                                          &ag, &configuration);
+  String syncData = measurements.toString(false, fwMode, wifiConnector.RSSI(), ag, configuration);
   if (apiClient.postToServer(syncData)) {
     Serial.println();
     Serial.println(
@@ -604,26 +586,54 @@ static void sendDataToServer(void) {
 }
 
 static void tempHumUpdate(void) {
-  delay(100);
   if (ag.sht.measure()) {
-    measurements.Temperature = ag.sht.getTemperature();
-    measurements.Humidity = ag.sht.getRelativeHumidity();
+    float temp = ag.sht.getTemperature();
+    float rhum = ag.sht.getRelativeHumidity();
 
-    Serial.printf("Temperature in C: %0.2f\r\n", measurements.Temperature);
-    Serial.printf("Relative Humidity: %d\r\n", measurements.Humidity);
-    Serial.printf("Temperature compensated in C: %0.2f\r\n",
-                  measurements.Temperature);
-    Serial.printf("Relative Humidity compensated: %d\r\n",
-                  measurements.Humidity);
+    measurements.update(Measurements::Temperature, temp);
+    measurements.update(Measurements::Humidity, rhum);
 
     // Update compensation temperature and humidity for SGP41
     if (configuration.hasSensorSGP) {
-      ag.sgp41.setCompensationTemperatureHumidity(measurements.Temperature,
-                                                  measurements.Humidity);
+      ag.sgp41.setCompensationTemperatureHumidity(temp, rhum);
     }
   } else {
+    measurements.update(Measurements::Temperature, utils::getInvalidTemperature());
+    measurements.update(Measurements::Humidity, utils::getInvalidHumidity());
     Serial.println("SHT read failed");
-    measurements.Temperature = utils::getInvalidTemperature();
-    measurements.Humidity = utils::getInvalidHumidity();
   }
+}
+
+/* Set max period for each measurement type based on sensor update interval*/
+void setMeasurementMaxPeriod() {
+  /// Max period for S8 sensors measurements
+  measurements.maxPeriod(Measurements::CO2, calculateMaxPeriod(SENSOR_CO2_UPDATE_INTERVAL));
+  /// Max period for SGP sensors measurements
+  measurements.maxPeriod(Measurements::TVOC, calculateMaxPeriod(SENSOR_TVOC_UPDATE_INTERVAL));
+  measurements.maxPeriod(Measurements::TVOCRaw, calculateMaxPeriod(SENSOR_TVOC_UPDATE_INTERVAL));
+  measurements.maxPeriod(Measurements::NOx, calculateMaxPeriod(SENSOR_TVOC_UPDATE_INTERVAL));
+  measurements.maxPeriod(Measurements::NOxRaw, calculateMaxPeriod(SENSOR_TVOC_UPDATE_INTERVAL));
+  /// Max period for PMS sensors measurements
+  measurements.maxPeriod(Measurements::PM25, calculateMaxPeriod(SENSOR_PM_UPDATE_INTERVAL));
+  measurements.maxPeriod(Measurements::PM01, calculateMaxPeriod(SENSOR_PM_UPDATE_INTERVAL));
+  measurements.maxPeriod(Measurements::PM10, calculateMaxPeriod(SENSOR_PM_UPDATE_INTERVAL));
+  measurements.maxPeriod(Measurements::PM03_PC, calculateMaxPeriod(SENSOR_PM_UPDATE_INTERVAL));
+  // Temperature and Humidity
+  if (configuration.hasSensorSHT) {
+    /// Max period for SHT sensors measurements
+    measurements.maxPeriod(Measurements::Temperature,
+                           calculateMaxPeriod(SENSOR_TEMP_HUM_UPDATE_INTERVAL));
+    measurements.maxPeriod(Measurements::Humidity,
+                           calculateMaxPeriod(SENSOR_TEMP_HUM_UPDATE_INTERVAL));
+  } else {
+    /// Temp and hum data retrieved from PMS5003T sensor
+    measurements.maxPeriod(Measurements::Temperature,
+                           calculateMaxPeriod(SENSOR_PM_UPDATE_INTERVAL));
+    measurements.maxPeriod(Measurements::Humidity, calculateMaxPeriod(SENSOR_PM_UPDATE_INTERVAL));
+  }
+}
+
+int calculateMaxPeriod(int updateInterval) {
+  // 0.5 is 50% reduced interval for max period
+  return (SERVER_SYNC_INTERVAL - (SERVER_SYNC_INTERVAL * 0.5)) / updateInterval;
 }

--- a/examples/DiyProIndoorV3_3/LocalServer.cpp
+++ b/examples/DiyProIndoorV3_3/LocalServer.cpp
@@ -53,9 +53,8 @@ void LocalServer::_GET_metrics(void) {
 }
 
 void LocalServer::_GET_measure(void) {
-  server.send(
-      200, "application/json",
-      measure.toString(true, fwMode, wifiConnector.RSSI(), ag, &config));
+  String toSend = measure.toString(true, fwMode, wifiConnector.RSSI(), *ag, config);
+  server.send(200, "application/json", toSend);
 }
 
 void LocalServer::setFwMode(AgFirmwareMode fwMode) { this->fwMode = fwMode; }

--- a/examples/DiyProIndoorV3_3/OpenMetrics.cpp
+++ b/examples/DiyProIndoorV3_3/OpenMetrics.cpp
@@ -73,19 +73,30 @@ String OpenMetrics::getPayload(void) {
   int pm03PCount = utils::getInvalidPmValue();
   int atmpCompensated = utils::getInvalidTemperature();
   int ahumCompensated = utils::getInvalidHumidity();
+  int tvoc = utils::getInvalidVOC();
+  int tvoc_raw = utils::getInvalidVOC();
+  int nox = utils::getInvalidNOx();
+  int nox_raw = utils::getInvalidNOx();
 
   if (config.hasSensorSHT) {
-    _temp = measure.Temperature;
-    _hum = measure.Humidity;
+    _temp = measure.getFloat(Measurements::Temperature);
+    _hum = measure.getFloat(Measurements::Humidity);
     atmpCompensated = _temp;
     ahumCompensated = _hum;
   }
 
   if (config.hasSensorPMS1) {
-    pm01 = measure.pm01_1;
-    pm25 = measure.pm25_1;
-    pm10 = measure.pm10_1;
-    pm03PCount = measure.pm03PCount_1;
+    pm01 = measure.get(Measurements::PM01);
+    pm25 = measure.get(Measurements::PM25);
+    pm10 = measure.get(Measurements::PM10);
+    pm03PCount = measure.get(Measurements::PM03_PC);
+  }
+
+  if (config.hasSensorSGP) {
+    tvoc = measure.get(Measurements::TVOC);
+    tvoc_raw = measure.get(Measurements::TVOCRaw);
+    nox = measure.get(Measurements::NOx);
+    nox_raw = measure.get(Measurements::NOxRaw);
   }
 
   if (config.hasSensorPMS1) {
@@ -120,33 +131,33 @@ String OpenMetrics::getPayload(void) {
   }
 
   if (config.hasSensorSGP) {
-    if (utils::isValidVOC(measure.TVOC)) {
+    if (utils::isValidVOC(tvoc)) {
       add_metric("tvoc_index",
                  "The processed Total Volatile Organic Compounds (TVOC) index "
                  "as measured by the AirGradient SGP sensor",
                  "gauge");
-      add_metric_point("", String(measure.TVOC));
+      add_metric_point("", String(tvoc));
     }
-    if (utils::isValidVOC(measure.TVOCRaw)) {
+    if (utils::isValidVOC(tvoc_raw)) {
       add_metric("tvoc_raw",
                  "The raw input value to the Total Volatile Organic Compounds "
                  "(TVOC) index as measured by the AirGradient SGP sensor",
                  "gauge");
-      add_metric_point("", String(measure.TVOCRaw));
+      add_metric_point("", String(tvoc_raw));
     }
-    if (utils::isValidNOx(measure.NOx)) {
+    if (utils::isValidNOx(nox)) {
       add_metric("nox_index",
                  "The processed Nitrous Oxide (NOx) index as measured by the "
                  "AirGradient SGP sensor",
                  "gauge");
-      add_metric_point("", String(measure.NOx));
+      add_metric_point("", String(nox));
     }
-    if (utils::isValidNOx(measure.NOxRaw)) {
+    if (utils::isValidNOx(nox_raw)) {
       add_metric("nox_raw",
                  "The raw input value to the Nitrous Oxide (NOx) index as "
                  "measured by the AirGradient SGP sensor",
                  "gauge");
-      add_metric_point("", String(measure.NOxRaw));
+      add_metric_point("", String(nox_raw));
     }
   }
 

--- a/examples/DiyProIndoorV4_2/DiyProIndoorV4_2.ino
+++ b/examples/DiyProIndoorV4_2/DiyProIndoorV4_2.ino
@@ -49,9 +49,8 @@ CC BY-SA 4.0 Attribution-ShareAlike 4.0 International License
 #define SENSOR_TVOC_UPDATE_INTERVAL 1000              /** ms */
 #define SENSOR_CO2_UPDATE_INTERVAL 4000               /** ms */
 #define SENSOR_PM_UPDATE_INTERVAL 2000                /** ms */
-#define SENSOR_TEMP_HUM_UPDATE_INTERVAL 2000          /** ms */
+#define SENSOR_TEMP_HUM_UPDATE_INTERVAL 6000          /** ms */
 #define DISPLAY_DELAY_SHOW_CONTENT_MS 2000            /** ms */
-#define FIRMWARE_CHECK_FOR_UPDATE_MS (60 * 60 * 1000) /** ms */
 
 static AirGradient ag(DIY_PRO_INDOOR_V4_2);
 static Configuration configuration(Serial);
@@ -69,7 +68,6 @@ static LocalServer localServer(Serial, openMetrics, measurements, configuration,
 static MqttClient mqttClient(Serial);
 
 static uint32_t factoryBtnPressTime = 0;
-static int getCO2FailCount = 0;
 static AgFirmwareMode fwMode = FW_MODE_I_42PS;
 
 static String fwNewVersion;
@@ -91,6 +89,8 @@ static void wdgFeedUpdate(void);
 static bool sgp41Init(void);
 static void wifiFactoryConfigure(void);
 static void mqttHandle(void);
+static int calculateMaxPeriod(int updateInterval);
+static void setMeasurementMaxPeriod();
 
 AgSchedule dispLedSchedule(DISP_UPDATE_INTERVAL, oledDisplaySchedule);
 AgSchedule configSchedule(SERVER_CONFIG_SYNC_INTERVAL,
@@ -131,6 +131,10 @@ void setup() {
 
   /** Init sensor */
   boardInit();
+  setMeasurementMaxPeriod();
+
+  // Uncomment below line to print every measurements reading update
+  // measurements.setDebug(true);
 
   /** Connecting wifi */
   bool connectToWifi = false;
@@ -255,17 +259,16 @@ void loop() {
 }
 
 static void co2Update(void) {
+  if (!configuration.hasSensorS8) {
+    // Device don't have S8 sensor
+    return;
+  }
+
   int value = ag.s8.getCo2();
   if (utils::isValidCO2(value)) {
-    measurements.CO2 = value;
-    getCO2FailCount = 0;
-    Serial.printf("CO2 (ppm): %d\r\n", measurements.CO2);
+    measurements.update(Measurements::CO2, value);
   } else {
-    getCO2FailCount++;
-    Serial.printf("Get CO2 failed: %d\r\n", getCO2FailCount);
-    if (getCO2FailCount >= 3) {
-      measurements.CO2 = utils::getInvalidCO2();
-    }
+    measurements.update(Measurements::CO2, utils::getInvalidCO2());
   }
 }
 
@@ -393,8 +396,7 @@ static void mqttHandle(void) {
   }
 
   if (mqttClient.isConnected()) {
-    String payload = measurements.toString(true, fwMode, wifiConnector.RSSI(),
-                                           &ag, &configuration);
+    String payload = measurements.toString(true, fwMode, wifiConnector.RSSI(), ag, configuration);
     String topic = "airgradient/readings/" + ag.deviceId();
     if (mqttClient.publish(topic.c_str(), payload.c_str(), payload.length())) {
       Serial.println("MQTT sync success");
@@ -583,46 +585,27 @@ static void oledDisplaySchedule(void) {
 }
 
 static void updateTvoc(void) {
-  measurements.TVOC = ag.sgp41.getTvocIndex();
-  measurements.TVOCRaw = ag.sgp41.getTvocRaw();
-  measurements.NOx = ag.sgp41.getNoxIndex();
-  measurements.NOxRaw = ag.sgp41.getNoxRaw();
+  if (!configuration.hasSensorSGP) {
+    return;
+  }
 
-  Serial.println();
-  Serial.printf("TVOC index: %d\r\n", measurements.TVOC);
-  Serial.printf("TVOC raw: %d\r\n", measurements.TVOCRaw);
-  Serial.printf("NOx index: %d\r\n", measurements.NOx);
-  Serial.printf("NOx raw: %d\r\n", measurements.NOxRaw);
+  measurements.update(Measurements::TVOC, ag.sgp41.getTvocIndex());
+  measurements.update(Measurements::TVOCRaw, ag.sgp41.getTvocRaw());
+  measurements.update(Measurements::NOx, ag.sgp41.getNoxIndex());
+  measurements.update(Measurements::NOxRaw, ag.sgp41.getNoxRaw());
 }
 
 static void updatePm(void) {
   if (ag.pms5003.connected()) {
-    measurements.pm01_1 = ag.pms5003.getPm01Ae();
-    measurements.pm25_1 = ag.pms5003.getPm25Ae();
-    measurements.pm10_1 = ag.pms5003.getPm10Ae();
-    measurements.pm03PCount_1 = ag.pms5003.getPm03ParticleCount();
-
-    Serial.println();
-    Serial.printf("PM1 ug/m3: %d\r\n", measurements.pm01_1);
-    Serial.printf("PM2.5 ug/m3: %d\r\n", measurements.pm25_1);
-    Serial.printf("PM10 ug/m3: %d\r\n", measurements.pm10_1);
-    Serial.printf("PM0.3 Count: %d\r\n", measurements.pm03PCount_1);
-    Serial.printf("PM firmware version: %d\r\n", ag.pms5003.getFirmwareVersion());
-    ag.pms5003.resetFailCount();
+    measurements.update(Measurements::PM01, ag.pms5003.getPm01Ae());
+    measurements.update(Measurements::PM25, ag.pms5003.getPm25Ae());
+    measurements.update(Measurements::PM10, ag.pms5003.getPm10Ae());
+    measurements.update(Measurements::PM03_PC, ag.pms5003.getPm03ParticleCount());
   } else {
-    ag.pms5003.updateFailCount();
-    Serial.printf("PMS read failed %d times\r\n", ag.pms5003.getFailCount());
-    if (ag.pms5003.getFailCount() >= PMS_FAIL_COUNT_SET_INVALID) {
-      measurements.pm01_1 = utils::getInvalidPmValue();
-      measurements.pm25_1 = utils::getInvalidPmValue();
-      measurements.pm10_1 = utils::getInvalidPmValue();
-      measurements.pm03PCount_1 = utils::getInvalidPmValue();
-    }
-
-    if(ag.pms5003.getFailCount() >= ag.pms5003.getFailCountMax()) {
-      Serial.printf("PMS failure count reach to max set %d, restarting...", ag.pms5003.getFailCountMax());
-      ESP.restart();
-    }
+    measurements.update(Measurements::PM01, utils::getInvalidPmValue());
+    measurements.update(Measurements::PM25, utils::getInvalidPmValue());
+    measurements.update(Measurements::PM10, utils::getInvalidPmValue());
+    measurements.update(Measurements::PM03_PC, utils::getInvalidPmValue());
   }
 }
 
@@ -633,8 +616,7 @@ static void sendDataToServer(void) {
     return;
   }
 
-  String syncData = measurements.toString(false, fwMode, wifiConnector.RSSI(),
-                                          &ag, &configuration);
+  String syncData = measurements.toString(false, fwMode, wifiConnector.RSSI(), ag, configuration);
   if (apiClient.postToServer(syncData)) {
     Serial.println();
     Serial.println(
@@ -645,26 +627,54 @@ static void sendDataToServer(void) {
 }
 
 static void tempHumUpdate(void) {
-  delay(100);
   if (ag.sht.measure()) {
-    measurements.Temperature = ag.sht.getTemperature();
-    measurements.Humidity = ag.sht.getRelativeHumidity();
+    float temp = ag.sht.getTemperature();
+    float rhum = ag.sht.getRelativeHumidity();
 
-    Serial.printf("Temperature in C: %0.2f\r\n", measurements.Temperature);
-    Serial.printf("Relative Humidity: %d\r\n", measurements.Humidity);
-    Serial.printf("Temperature compensated in C: %0.2f\r\n",
-                  measurements.Temperature);
-    Serial.printf("Relative Humidity compensated: %d\r\n",
-                  measurements.Humidity);
+    measurements.update(Measurements::Temperature, temp);
+    measurements.update(Measurements::Humidity, rhum);
 
     // Update compensation temperature and humidity for SGP41
     if (configuration.hasSensorSGP) {
-      ag.sgp41.setCompensationTemperatureHumidity(measurements.Temperature,
-                                                  measurements.Humidity);
+      ag.sgp41.setCompensationTemperatureHumidity(temp, rhum);
     }
   } else {
+    measurements.update(Measurements::Temperature, utils::getInvalidTemperature());
+    measurements.update(Measurements::Humidity, utils::getInvalidHumidity());
     Serial.println("SHT read failed");
-    measurements.Temperature = utils::getInvalidTemperature();
-    measurements.Humidity = utils::getInvalidHumidity();
   }
+}
+
+/* Set max period for each measurement type based on sensor update interval*/
+void setMeasurementMaxPeriod() {
+  /// Max period for S8 sensors measurements
+  measurements.maxPeriod(Measurements::CO2, calculateMaxPeriod(SENSOR_CO2_UPDATE_INTERVAL));
+  /// Max period for SGP sensors measurements
+  measurements.maxPeriod(Measurements::TVOC, calculateMaxPeriod(SENSOR_TVOC_UPDATE_INTERVAL));
+  measurements.maxPeriod(Measurements::TVOCRaw, calculateMaxPeriod(SENSOR_TVOC_UPDATE_INTERVAL));
+  measurements.maxPeriod(Measurements::NOx, calculateMaxPeriod(SENSOR_TVOC_UPDATE_INTERVAL));
+  measurements.maxPeriod(Measurements::NOxRaw, calculateMaxPeriod(SENSOR_TVOC_UPDATE_INTERVAL));
+  /// Max period for PMS sensors measurements
+  measurements.maxPeriod(Measurements::PM25, calculateMaxPeriod(SENSOR_PM_UPDATE_INTERVAL));
+  measurements.maxPeriod(Measurements::PM01, calculateMaxPeriod(SENSOR_PM_UPDATE_INTERVAL));
+  measurements.maxPeriod(Measurements::PM10, calculateMaxPeriod(SENSOR_PM_UPDATE_INTERVAL));
+  measurements.maxPeriod(Measurements::PM03_PC, calculateMaxPeriod(SENSOR_PM_UPDATE_INTERVAL));
+  // Temperature and Humidity
+  if (configuration.hasSensorSHT) {
+    /// Max period for SHT sensors measurements
+    measurements.maxPeriod(Measurements::Temperature,
+                           calculateMaxPeriod(SENSOR_TEMP_HUM_UPDATE_INTERVAL));
+    measurements.maxPeriod(Measurements::Humidity,
+                           calculateMaxPeriod(SENSOR_TEMP_HUM_UPDATE_INTERVAL));
+  } else {
+    /// Temp and hum data retrieved from PMS5003T sensor
+    measurements.maxPeriod(Measurements::Temperature,
+                           calculateMaxPeriod(SENSOR_PM_UPDATE_INTERVAL));
+    measurements.maxPeriod(Measurements::Humidity, calculateMaxPeriod(SENSOR_PM_UPDATE_INTERVAL));
+  }
+}
+
+int calculateMaxPeriod(int updateInterval) {
+  // 0.5 is 50% reduced interval for max period
+  return (SERVER_SYNC_INTERVAL - (SERVER_SYNC_INTERVAL * 0.5)) / updateInterval;
 }

--- a/examples/DiyProIndoorV4_2/LocalServer.cpp
+++ b/examples/DiyProIndoorV4_2/LocalServer.cpp
@@ -53,9 +53,8 @@ void LocalServer::_GET_metrics(void) {
 }
 
 void LocalServer::_GET_measure(void) {
-  server.send(
-      200, "application/json",
-      measure.toString(true, fwMode, wifiConnector.RSSI(), ag, &config));
+  String toSend = measure.toString(true, fwMode, wifiConnector.RSSI(), *ag, config);
+  server.send(200, "application/json", toSend);
 }
 
 void LocalServer::setFwMode(AgFirmwareMode fwMode) { this->fwMode = fwMode; }

--- a/examples/DiyProIndoorV4_2/OpenMetrics.cpp
+++ b/examples/DiyProIndoorV4_2/OpenMetrics.cpp
@@ -73,19 +73,30 @@ String OpenMetrics::getPayload(void) {
   int pm03PCount = utils::getInvalidPmValue();
   int atmpCompensated = utils::getInvalidTemperature();
   int ahumCompensated = utils::getInvalidHumidity();
+  int tvoc = utils::getInvalidVOC();
+  int tvoc_raw = utils::getInvalidVOC();
+  int nox = utils::getInvalidNOx();
+  int nox_raw = utils::getInvalidNOx();
 
   if (config.hasSensorSHT) {
-    _temp = measure.Temperature;
-    _hum = measure.Humidity;
+    _temp = measure.getFloat(Measurements::Temperature);
+    _hum = measure.getFloat(Measurements::Humidity);
     atmpCompensated = _temp;
     ahumCompensated = _hum;
   }
 
   if (config.hasSensorPMS1) {
-    pm01 = measure.pm01_1;
-    pm25 = measure.pm25_1;
-    pm10 = measure.pm10_1;
-    pm03PCount = measure.pm03PCount_1;
+    pm01 = measure.get(Measurements::PM01);
+    pm25 = measure.get(Measurements::PM25);
+    pm10 = measure.get(Measurements::PM10);
+    pm03PCount = measure.get(Measurements::PM03_PC);
+  }
+
+  if (config.hasSensorSGP) {
+    tvoc = measure.get(Measurements::TVOC);
+    tvoc_raw = measure.get(Measurements::TVOCRaw);
+    nox = measure.get(Measurements::NOx);
+    nox_raw = measure.get(Measurements::NOxRaw);
   }
 
   if (config.hasSensorPMS1) {
@@ -120,33 +131,33 @@ String OpenMetrics::getPayload(void) {
   }
 
   if (config.hasSensorSGP) {
-    if (utils::isValidVOC(measure.TVOC)) {
+    if (utils::isValidVOC(tvoc)) {
       add_metric("tvoc_index",
                  "The processed Total Volatile Organic Compounds (TVOC) index "
                  "as measured by the AirGradient SGP sensor",
                  "gauge");
-      add_metric_point("", String(measure.TVOC));
+      add_metric_point("", String(tvoc));
     }
-    if (utils::isValidVOC(measure.TVOCRaw)) {
+    if (utils::isValidVOC(tvoc_raw)) {
       add_metric("tvoc_raw",
                  "The raw input value to the Total Volatile Organic Compounds "
                  "(TVOC) index as measured by the AirGradient SGP sensor",
                  "gauge");
-      add_metric_point("", String(measure.TVOCRaw));
+      add_metric_point("", String(tvoc_raw));
     }
-    if (utils::isValidNOx(measure.NOx)) {
+    if (utils::isValidNOx(nox)) {
       add_metric("nox_index",
                  "The processed Nitrous Oxide (NOx) index as measured by the "
                  "AirGradient SGP sensor",
                  "gauge");
-      add_metric_point("", String(measure.NOx));
+      add_metric_point("", String(nox));
     }
-    if (utils::isValidNOx(measure.NOxRaw)) {
+    if (utils::isValidNOx(nox_raw)) {
       add_metric("nox_raw",
                  "The raw input value to the Nitrous Oxide (NOx) index as "
                  "measured by the AirGradient SGP sensor",
                  "gauge");
-      add_metric_point("", String(measure.NOxRaw));
+      add_metric_point("", String(nox_raw));
     }
   }
 

--- a/examples/OneOpenAir/LocalServer.cpp
+++ b/examples/OneOpenAir/LocalServer.cpp
@@ -64,7 +64,7 @@ void LocalServer::_GET_metrics(void) {
 }
 
 void LocalServer::_GET_measure(void) {
-  String toSend = measure.toStringX(true, fwMode, wifiConnector.RSSI(), *ag, config);
+  String toSend = measure.toString(true, fwMode, wifiConnector.RSSI(), *ag, config);
   server.send(200, "application/json", toSend);
 }
 

--- a/examples/OneOpenAir/LocalServer.cpp
+++ b/examples/OneOpenAir/LocalServer.cpp
@@ -64,9 +64,8 @@ void LocalServer::_GET_metrics(void) {
 }
 
 void LocalServer::_GET_measure(void) {
-  server.send(
-      200, "application/json",
-      measure.toString(true, fwMode, wifiConnector.RSSI(), ag, &config));
+  String toSend = measure.toStringX(true, fwMode, wifiConnector.RSSI(), *ag, config);
+  server.send(200, "application/json", toSend);
 }
 
 void LocalServer::setFwMode(AgFirmwareMode fwMode) { this->fwMode = fwMode; }

--- a/examples/OneOpenAir/OneOpenAir.ino
+++ b/examples/OneOpenAir/OneOpenAir.ino
@@ -263,17 +263,17 @@ void setup() {
   updateDisplayAndLedBar();
 
   // NOTE: This is just a temporary, will do a proper set maximum value based on schedule interval
-  measurements.maxUpdate(Measurements::AgValueType::Temperature, 26);
-  measurements.maxUpdate(Measurements::AgValueType::Humidity, 26);
-  measurements.maxUpdate(Measurements::AgValueType::CO2, 13);
-  measurements.maxUpdate(Measurements::AgValueType::TVOC, 53);
-  measurements.maxUpdate(Measurements::AgValueType::TVOCRaw, 53);
-  measurements.maxUpdate(Measurements::AgValueType::NOx, 53);
-  measurements.maxUpdate(Measurements::AgValueType::NOxRaw, 53);
-  measurements.maxUpdate(Measurements::AgValueType::PM25, 26);
-  measurements.maxUpdate(Measurements::AgValueType::PM01, 26);
-  measurements.maxUpdate(Measurements::AgValueType::PM10, 26);
-  measurements.maxUpdate(Measurements::AgValueType::PM03_PC, 26);
+  measurements.maxUpdate(Measurements::Temperature, 26);
+  measurements.maxUpdate(Measurements::Humidity, 26);
+  measurements.maxUpdate(Measurements::CO2, 13);
+  measurements.maxUpdate(Measurements::TVOC, 53);
+  measurements.maxUpdate(Measurements::TVOCRaw, 53);
+  measurements.maxUpdate(Measurements::NOx, 53);
+  measurements.maxUpdate(Measurements::NOxRaw, 53);
+  measurements.maxUpdate(Measurements::PM25, 26);
+  measurements.maxUpdate(Measurements::PM01, 26);
+  measurements.maxUpdate(Measurements::PM10, 26);
+  measurements.maxUpdate(Measurements::PM03_PC, 26);
 }
 
 void loop() {

--- a/examples/OneOpenAir/OneOpenAir.ino
+++ b/examples/OneOpenAir/OneOpenAir.ino
@@ -1176,5 +1176,6 @@ void setMeasurementMaxPeriod() {
 }
 
 int calculateMaxPeriod(int updateInterval) {
-  return (SERVER_SYNC_INTERVAL - (SERVER_SYNC_INTERVAL * 0.1)) / updateInterval;
+  // 0.5 is 50% reduced interval for max period
+  return (SERVER_SYNC_INTERVAL - (SERVER_SYNC_INTERVAL * 0.5)) / updateInterval;
 }

--- a/examples/OneOpenAir/OneOpenAir.ino
+++ b/examples/OneOpenAir/OneOpenAir.ino
@@ -337,10 +337,10 @@ static void co2Update(void) {
 
   int value = ag->s8.getCo2();
   if (utils::isValidCO2(value)) {
-    measurements.updateValue(Measurements::AgValueType::CO2, value);
+    measurements.update(Measurements::CO2, value);
     // Serial.printf("CO2 (ppm): %d\r\n", measurements.CO2);
   } else {
-    measurements.updateValue(Measurements::AgValueType::CO2, utils::getInvalidCO2());
+    measurements.update(Measurements::CO2, utils::getInvalidCO2());
   }
 }
 
@@ -374,7 +374,7 @@ static void createMqttTask(void) {
           /** Send data */
           if (mqttClient.isConnected()) {
             String payload =
-                measurements.toStringX(true, fwMode, wifiConnector.RSSI(), *ag, configuration);
+                measurements.toString(true, fwMode, wifiConnector.RSSI(), *ag, configuration);
             String topic = "airgradient/readings/" + ag->deviceId();
 
             if (mqttClient.publish(topic.c_str(), payload.c_str(),
@@ -999,10 +999,10 @@ static void updateTvoc(void) {
     return;
   }
 
-  measurements.updateValue(Measurements::AgValueType::TVOC, ag->sgp41.getTvocIndex());
-  measurements.updateValue(Measurements::AgValueType::TVOCRaw, ag->sgp41.getTvocRaw());
-  measurements.updateValue(Measurements::AgValueType::NOx, ag->sgp41.getNoxIndex());
-  measurements.updateValue(Measurements::AgValueType::NOxRaw, ag->sgp41.getNoxRaw());
+  measurements.update(Measurements::TVOC, ag->sgp41.getTvocIndex());
+  measurements.update(Measurements::TVOCRaw, ag->sgp41.getTvocRaw());
+  measurements.update(Measurements::NOx, ag->sgp41.getNoxIndex());
+  measurements.update(Measurements::NOxRaw, ag->sgp41.getNoxRaw());
 
   // Serial.println();
   // Serial.printf("TVOC index: %d\r\n", measurements.TVOC);
@@ -1013,11 +1013,10 @@ static void updateTvoc(void) {
 
 static void updatePMS5003() {
   if (ag->pms5003.connected()) {
-    measurements.updateValue(Measurements::AgValueType::PM01, ag->pms5003.getPm01Ae());
-    measurements.updateValue(Measurements::AgValueType::PM25, ag->pms5003.getPm25Ae());
-    measurements.updateValue(Measurements::AgValueType::PM10, ag->pms5003.getPm10Ae());
-    measurements.updateValue(Measurements::AgValueType::PM03_PC,
-                             ag->pms5003.getPm03ParticleCount());
+    measurements.update(Measurements::PM01, ag->pms5003.getPm01Ae());
+    measurements.update(Measurements::PM25, ag->pms5003.getPm25Ae());
+    measurements.update(Measurements::PM10, ag->pms5003.getPm10Ae());
+    measurements.update(Measurements::PM03_PC, ag->pms5003.getPm03ParticleCount());
 
     // Serial.println();
     // Serial.printf("PM1 ug/m3: %d\r\n", measurements.pm01_1);
@@ -1026,10 +1025,10 @@ static void updatePMS5003() {
     // Serial.printf("PM0.3 Count: %d\r\n", measurements.pm03PCount_1);
     // Serial.printf("PM firmware version: %d\r\n", ag->pms5003.getFirmwareVersion());
   } else {
-    measurements.updateValue(Measurements::AgValueType::PM01, utils::getInvalidPmValue());
-    measurements.updateValue(Measurements::AgValueType::PM25, utils::getInvalidPmValue());
-    measurements.updateValue(Measurements::AgValueType::PM10, utils::getInvalidPmValue());
-    measurements.updateValue(Measurements::AgValueType::PM03_PC, utils::getInvalidPmValue());
+    measurements.update(Measurements::PM01, utils::getInvalidPmValue());
+    measurements.update(Measurements::PM25, utils::getInvalidPmValue());
+    measurements.update(Measurements::PM10, utils::getInvalidPmValue());
+    measurements.update(Measurements::PM03_PC, utils::getInvalidPmValue());
   }
 }
 
@@ -1047,35 +1046,23 @@ static void updatePm(void) {
   int channel = 1;
   if (configuration.hasSensorPMS1) {
     if (ag->pms5003t_1.connected()) {
-      measurements.updateValue(Measurements::AgValueType::PM01, ag->pms5003t_1.getPm01Ae(),
-                               channel);
-      measurements.updateValue(Measurements::AgValueType::PM25, ag->pms5003t_1.getPm25Ae(),
-                               channel);
-      measurements.updateValue(Measurements::AgValueType::PM10, ag->pms5003t_1.getPm10Ae(),
-                               channel);
-      measurements.updateValue(Measurements::AgValueType::PM03_PC,
-                               ag->pms5003t_1.getPm03ParticleCount(), channel);
-      measurements.updateValue(Measurements::AgValueType::Temperature,
-                               ag->pms5003t_1.getTemperature(), channel);
-      measurements.updateValue(Measurements::AgValueType::Humidity,
-                               ag->pms5003t_1.getRelativeHumidity(), channel);
+      measurements.update(Measurements::PM01, ag->pms5003t_1.getPm01Ae(), channel);
+      measurements.update(Measurements::PM25, ag->pms5003t_1.getPm25Ae(), channel);
+      measurements.update(Measurements::PM10, ag->pms5003t_1.getPm10Ae(), channel);
+      measurements.update(Measurements::PM03_PC, ag->pms5003t_1.getPm03ParticleCount(), channel);
+      measurements.update(Measurements::Temperature, ag->pms5003t_1.getTemperature(), channel);
+      measurements.update(Measurements::Humidity, ag->pms5003t_1.getRelativeHumidity(), channel);
 
       // flag that new valid PMS value exists
       newPMS2Value = true;
     } else {
       // PMS channel 1 now is not connected, update using invalid value
-      measurements.updateValue(Measurements::AgValueType::PM01, utils::getInvalidPmValue(),
-                               channel);
-      measurements.updateValue(Measurements::AgValueType::PM25, utils::getInvalidPmValue(),
-                               channel);
-      measurements.updateValue(Measurements::AgValueType::PM10, utils::getInvalidPmValue(),
-                               channel);
-      measurements.updateValue(Measurements::AgValueType::PM03_PC, utils::getInvalidPmValue(),
-                               channel);
-      measurements.updateValue(Measurements::AgValueType::Temperature,
-                               utils::getInvalidTemperature(), channel);
-      measurements.updateValue(Measurements::AgValueType::Humidity, utils::getInvalidHumidity(),
-                               channel);
+      measurements.update(Measurements::PM01, utils::getInvalidPmValue(), channel);
+      measurements.update(Measurements::PM25, utils::getInvalidPmValue(), channel);
+      measurements.update(Measurements::PM10, utils::getInvalidPmValue(), channel);
+      measurements.update(Measurements::PM03_PC, utils::getInvalidPmValue(), channel);
+      measurements.update(Measurements::Temperature, utils::getInvalidTemperature(), channel);
+      measurements.update(Measurements::Humidity, utils::getInvalidHumidity(), channel);
     }
   }
 
@@ -1083,35 +1070,23 @@ static void updatePm(void) {
   channel = 2;
   if (configuration.hasSensorPMS2) {
     if (ag->pms5003t_2.connected()) {
-      measurements.updateValue(Measurements::AgValueType::PM01, ag->pms5003t_2.getPm01Ae(),
-                               channel);
-      measurements.updateValue(Measurements::AgValueType::PM25, ag->pms5003t_2.getPm25Ae(),
-                               channel);
-      measurements.updateValue(Measurements::AgValueType::PM10, ag->pms5003t_2.getPm10Ae(),
-                               channel);
-      measurements.updateValue(Measurements::AgValueType::PM03_PC,
-                               ag->pms5003t_2.getPm03ParticleCount(), channel);
-      measurements.updateValue(Measurements::AgValueType::Temperature,
-                               ag->pms5003t_2.getTemperature(), channel);
-      measurements.updateValue(Measurements::AgValueType::Humidity,
-                               ag->pms5003t_2.getRelativeHumidity(), channel);
+      measurements.update(Measurements::PM01, ag->pms5003t_2.getPm01Ae(), channel);
+      measurements.update(Measurements::PM25, ag->pms5003t_2.getPm25Ae(), channel);
+      measurements.update(Measurements::PM10, ag->pms5003t_2.getPm10Ae(), channel);
+      measurements.update(Measurements::PM03_PC, ag->pms5003t_2.getPm03ParticleCount(), channel);
+      measurements.update(Measurements::Temperature, ag->pms5003t_2.getTemperature(), channel);
+      measurements.update(Measurements::Humidity, ag->pms5003t_2.getRelativeHumidity(), channel);
 
       // flag that new valid PMS value exists
       newPMS2Value = true;
     } else {
       // PMS channel channel now is not connected, update using invalid value
-      measurements.updateValue(Measurements::AgValueType::PM01, utils::getInvalidPmValue(),
-                               channel);
-      measurements.updateValue(Measurements::AgValueType::PM25, utils::getInvalidPmValue(),
-                               channel);
-      measurements.updateValue(Measurements::AgValueType::PM10, utils::getInvalidPmValue(),
-                               channel);
-      measurements.updateValue(Measurements::AgValueType::PM03_PC, utils::getInvalidPmValue(),
-                               channel);
-      measurements.updateValue(Measurements::AgValueType::Temperature,
-                               utils::getInvalidTemperature(), channel);
-      measurements.updateValue(Measurements::AgValueType::Humidity, utils::getInvalidHumidity(),
-                               channel);
+      measurements.update(Measurements::PM01, utils::getInvalidPmValue(), channel);
+      measurements.update(Measurements::PM25, utils::getInvalidPmValue(), channel);
+      measurements.update(Measurements::PM10, utils::getInvalidPmValue(), channel);
+      measurements.update(Measurements::PM03_PC, utils::getInvalidPmValue(), channel);
+      measurements.update(Measurements::Temperature, utils::getInvalidTemperature(), channel);
+      measurements.update(Measurements::Humidity, utils::getInvalidHumidity(), channel);
     }
   }
 
@@ -1119,20 +1094,20 @@ static void updatePm(void) {
     float temp, hum;
     if (newPMS1Value && newPMS2Value) {
       // Both PMS has new valid value
-      temp = (measurements.getValueFloat(Measurements::AgValueType::Temperature, false, 1) +
-              measurements.getValueFloat(Measurements::AgValueType::Temperature, false, 2)) /
+      temp = (measurements.getFloat(Measurements::Temperature, false, 1) +
+              measurements.getFloat(Measurements::Temperature, false, 2)) /
              2.0f;
-      hum = (measurements.getValueFloat(Measurements::AgValueType::Humidity, false, 1) +
-             measurements.getValueFloat(Measurements::AgValueType::Humidity, false, 2)) /
+      hum = (measurements.getFloat(Measurements::Humidity, false, 1) +
+             measurements.getFloat(Measurements::Humidity, false, 2)) /
             2.0f;
     } else if (newPMS1Value) {
       // Only PMS1 has new valid value
-      temp = measurements.getValueFloat(Measurements::AgValueType::Temperature, false, 1);
-      hum = measurements.getValueFloat(Measurements::AgValueType::Humidity, false, 1);
+      temp = measurements.getFloat(Measurements::Temperature, false, 1);
+      hum = measurements.getFloat(Measurements::Humidity, false, 1);
     } else {
       // Only PMS2 has new valid value
-      temp = measurements.getValueFloat(Measurements::AgValueType::Temperature, false, 2);
-      hum = measurements.getValueFloat(Measurements::AgValueType::Humidity, false, 2);
+      temp = measurements.getFloat(Measurements::Temperature, false, 2);
+      hum = measurements.getFloat(Measurements::Humidity, false, 2);
     }
 
     // Update compensation temperature and humidity for SGP41
@@ -1146,7 +1121,7 @@ static void sendDataToServer(void) {
     return;
   }
 
-  String syncData = measurements.toStringX(false, fwMode, wifiConnector.RSSI(), *ag, configuration);
+  String syncData = measurements.toString(false, fwMode, wifiConnector.RSSI(), *ag, configuration);
   if (apiClient.postToServer(syncData)) {
     Serial.println();
     Serial.println(
@@ -1162,8 +1137,8 @@ static void tempHumUpdate(void) {
     float temp = ag->sht.getTemperature();
     float rhum = ag->sht.getRelativeHumidity();
 
-    measurements.updateValue(Measurements::AgValueType::Temperature, temp);
-    measurements.updateValue(Measurements::AgValueType::Humidity, rhum);
+    measurements.update(Measurements::Temperature, temp);
+    measurements.update(Measurements::Humidity, rhum);
 
     // Serial.printf("Temperature in C: %0.2f\n", temp);
     // Serial.printf("Relative Humidity: %d\n", rhum);
@@ -1175,9 +1150,8 @@ static void tempHumUpdate(void) {
       ag->sgp41.setCompensationTemperatureHumidity(temp, rhum);
     }
   } else {
-    measurements.updateValue(Measurements::AgValueType::Temperature,
-                             utils::getInvalidTemperature());
-    measurements.updateValue(Measurements::AgValueType::Humidity, utils::getInvalidHumidity());
+    measurements.update(Measurements::Temperature, utils::getInvalidTemperature());
+    measurements.update(Measurements::Humidity, utils::getInvalidHumidity());
     Serial.println("SHT read failed");
   }
 }

--- a/examples/OneOpenAir/OneOpenAir.ino
+++ b/examples/OneOpenAir/OneOpenAir.ino
@@ -169,6 +169,9 @@ void setup() {
   boardInit();
   setMeasurementMaxPeriod();
 
+  // Uncomment below line to print every measurements reading update
+  // measurements.setDebug(true);
+
   /** Connecting wifi */
   bool connectToWifi = false;
   if (ag->isOne()) {

--- a/examples/OneOpenAir/OneOpenAir.ino
+++ b/examples/OneOpenAir/OneOpenAir.ino
@@ -89,7 +89,6 @@ static LocalServer localServer(Serial, openMetrics, measurements, configuration,
                                wifiConnector);
 
 static uint32_t factoryBtnPressTime = 0;
-static int getCO2FailCount = 0;
 static AgFirmwareMode fwMode = FW_MODE_I_9PSL;
 
 static bool ledBarButtonTest = false;
@@ -324,14 +323,13 @@ void loop() {
 
 static void co2Update(void) {
   if (!configuration.hasSensorS8) {
-    // Device don't have SHT sensor
+    // Device don't have S8 sensor
     return;
   }
 
   int value = ag->s8.getCo2();
   if (utils::isValidCO2(value)) {
     measurements.update(Measurements::CO2, value);
-    // Serial.printf("CO2 (ppm): %d\r\n", measurements.CO2);
   } else {
     measurements.update(Measurements::CO2, utils::getInvalidCO2());
   }
@@ -996,12 +994,6 @@ static void updateTvoc(void) {
   measurements.update(Measurements::TVOCRaw, ag->sgp41.getTvocRaw());
   measurements.update(Measurements::NOx, ag->sgp41.getNoxIndex());
   measurements.update(Measurements::NOxRaw, ag->sgp41.getNoxRaw());
-
-  // Serial.println();
-  // Serial.printf("TVOC index: %d\r\n", measurements.TVOC);
-  // Serial.printf("TVOC raw: %d\r\n", measurements.TVOCRaw);
-  // Serial.printf("NOx index: %d\r\n", measurements.NOx);
-  // Serial.printf("NOx raw: %d\r\n", measurements.NOxRaw);
 }
 
 static void updatePMS5003() {
@@ -1010,13 +1002,6 @@ static void updatePMS5003() {
     measurements.update(Measurements::PM25, ag->pms5003.getPm25Ae());
     measurements.update(Measurements::PM10, ag->pms5003.getPm10Ae());
     measurements.update(Measurements::PM03_PC, ag->pms5003.getPm03ParticleCount());
-
-    // Serial.println();
-    // Serial.printf("PM1 ug/m3: %d\r\n", measurements.pm01_1);
-    // Serial.printf("PM2.5 ug/m3: %d\r\n", measurements.pm25_1);
-    // Serial.printf("PM10 ug/m3: %d\r\n", measurements.pm10_1);
-    // Serial.printf("PM0.3 Count: %d\r\n", measurements.pm03PCount_1);
-    // Serial.printf("PM firmware version: %d\r\n", ag->pms5003.getFirmwareVersion());
   } else {
     measurements.update(Measurements::PM01, utils::getInvalidPmValue());
     measurements.update(Measurements::PM25, utils::getInvalidPmValue());
@@ -1132,11 +1117,6 @@ static void tempHumUpdate(void) {
 
     measurements.update(Measurements::Temperature, temp);
     measurements.update(Measurements::Humidity, rhum);
-
-    // Serial.printf("Temperature in C: %0.2f\n", temp);
-    // Serial.printf("Relative Humidity: %d\n", rhum);
-    // Serial.printf("Temperature compensated in C: %0.2f\n", temp);
-    // Serial.printf("Relative Humidity compensated: %0.2f\n", rhum);
 
     // Update compensation temperature and humidity for SGP41
     if (configuration.hasSensorSGP) {

--- a/examples/OneOpenAir/OneOpenAir.ino
+++ b/examples/OneOpenAir/OneOpenAir.ino
@@ -373,8 +373,8 @@ static void createMqttTask(void) {
 
           /** Send data */
           if (mqttClient.isConnected()) {
-            String payload = measurements.toString(
-                true, fwMode, wifiConnector.RSSI(), ag, &configuration);
+            String payload =
+                measurements.toStringX(true, fwMode, wifiConnector.RSSI(), *ag, configuration);
             String topic = "airgradient/readings/" + ag->deviceId();
 
             if (mqttClient.publish(topic.c_str(), payload.c_str(),
@@ -1146,8 +1146,7 @@ static void sendDataToServer(void) {
     return;
   }
 
-  String syncData = measurements.toString(false, fwMode, wifiConnector.RSSI(),
-                                          ag, &configuration);
+  String syncData = measurements.toStringX(false, fwMode, wifiConnector.RSSI(), *ag, configuration);
   if (apiClient.postToServer(syncData)) {
     Serial.println();
     Serial.println(

--- a/examples/OneOpenAir/OneOpenAir.ino
+++ b/examples/OneOpenAir/OneOpenAir.ino
@@ -116,6 +116,7 @@ static void otaHandlerCallback(OtaState state, String mesasge);
 static void displayExecuteOta(OtaState state, String msg,
                               int processing);
 static int calculateMaxPeriod(int updateInterval);
+static void setMeasurementMaxPeriod();
 
 AgSchedule dispLedSchedule(DISP_UPDATE_INTERVAL, updateDisplayAndLedBar);
 AgSchedule configSchedule(SERVER_CONFIG_SYNC_INTERVAL,
@@ -166,32 +167,7 @@ void setup() {
 
   /** Init sensor */
   boardInit();
-
-  /* Set max period for each measurement type based on sensor update interval*/
-  if (configuration.hasSensorSHT) {
-    /// Max period for SHT sensors measurements
-    measurements.maxPeriod(Measurements::Temperature,
-                           calculateMaxPeriod(SENSOR_TEMP_HUM_UPDATE_INTERVAL));
-    measurements.maxPeriod(Measurements::Humidity,
-                           calculateMaxPeriod(SENSOR_TEMP_HUM_UPDATE_INTERVAL));
-  } else {
-    /// Temp and hum data retrieved from PMS5003T sensor
-    measurements.maxPeriod(Measurements::Temperature,
-                           calculateMaxPeriod(SENSOR_PM_UPDATE_INTERVAL));
-    measurements.maxPeriod(Measurements::Humidity, calculateMaxPeriod(SENSOR_PM_UPDATE_INTERVAL));
-  }
-  /// Max period for S8 sensors measurements
-  measurements.maxPeriod(Measurements::CO2, calculateMaxPeriod(SENSOR_CO2_UPDATE_INTERVAL));
-  /// Max period for SGP sensors measurements
-  measurements.maxPeriod(Measurements::TVOC, calculateMaxPeriod(SENSOR_TVOC_UPDATE_INTERVAL));
-  measurements.maxPeriod(Measurements::TVOCRaw, calculateMaxPeriod(SENSOR_TVOC_UPDATE_INTERVAL));
-  measurements.maxPeriod(Measurements::NOx, calculateMaxPeriod(SENSOR_TVOC_UPDATE_INTERVAL));
-  measurements.maxPeriod(Measurements::NOxRaw, calculateMaxPeriod(SENSOR_TVOC_UPDATE_INTERVAL));
-  /// Max period for PMS sensors measurements
-  measurements.maxPeriod(Measurements::PM25, calculateMaxPeriod(SENSOR_PM_UPDATE_INTERVAL));
-  measurements.maxPeriod(Measurements::PM01, calculateMaxPeriod(SENSOR_PM_UPDATE_INTERVAL));
-  measurements.maxPeriod(Measurements::PM10, calculateMaxPeriod(SENSOR_PM_UPDATE_INTERVAL));
-  measurements.maxPeriod(Measurements::PM03_PC, calculateMaxPeriod(SENSOR_PM_UPDATE_INTERVAL));
+  setMeasurementMaxPeriod();
 
   /** Connecting wifi */
   bool connectToWifi = false;
@@ -1167,6 +1143,35 @@ static void tempHumUpdate(void) {
     measurements.update(Measurements::Temperature, utils::getInvalidTemperature());
     measurements.update(Measurements::Humidity, utils::getInvalidHumidity());
     Serial.println("SHT read failed");
+  }
+}
+
+/* Set max period for each measurement type based on sensor update interval*/
+void setMeasurementMaxPeriod() {
+  /// Max period for S8 sensors measurements
+  measurements.maxPeriod(Measurements::CO2, calculateMaxPeriod(SENSOR_CO2_UPDATE_INTERVAL));
+  /// Max period for SGP sensors measurements
+  measurements.maxPeriod(Measurements::TVOC, calculateMaxPeriod(SENSOR_TVOC_UPDATE_INTERVAL));
+  measurements.maxPeriod(Measurements::TVOCRaw, calculateMaxPeriod(SENSOR_TVOC_UPDATE_INTERVAL));
+  measurements.maxPeriod(Measurements::NOx, calculateMaxPeriod(SENSOR_TVOC_UPDATE_INTERVAL));
+  measurements.maxPeriod(Measurements::NOxRaw, calculateMaxPeriod(SENSOR_TVOC_UPDATE_INTERVAL));
+  /// Max period for PMS sensors measurements
+  measurements.maxPeriod(Measurements::PM25, calculateMaxPeriod(SENSOR_PM_UPDATE_INTERVAL));
+  measurements.maxPeriod(Measurements::PM01, calculateMaxPeriod(SENSOR_PM_UPDATE_INTERVAL));
+  measurements.maxPeriod(Measurements::PM10, calculateMaxPeriod(SENSOR_PM_UPDATE_INTERVAL));
+  measurements.maxPeriod(Measurements::PM03_PC, calculateMaxPeriod(SENSOR_PM_UPDATE_INTERVAL));
+  // Temperature and Humidity
+  if (configuration.hasSensorSHT) {
+    /// Max period for SHT sensors measurements
+    measurements.maxPeriod(Measurements::Temperature,
+                           calculateMaxPeriod(SENSOR_TEMP_HUM_UPDATE_INTERVAL));
+    measurements.maxPeriod(Measurements::Humidity,
+                           calculateMaxPeriod(SENSOR_TEMP_HUM_UPDATE_INTERVAL));
+  } else {
+    /// Temp and hum data retrieved from PMS5003T sensor
+    measurements.maxPeriod(Measurements::Temperature,
+                           calculateMaxPeriod(SENSOR_PM_UPDATE_INTERVAL));
+    measurements.maxPeriod(Measurements::Humidity, calculateMaxPeriod(SENSOR_PM_UPDATE_INTERVAL));
   }
 }
 

--- a/examples/OneOpenAir/OneOpenAir.ino
+++ b/examples/OneOpenAir/OneOpenAir.ino
@@ -1094,20 +1094,20 @@ static void updatePm(void) {
     float temp, hum;
     if (newPMS1Value && newPMS2Value) {
       // Both PMS has new valid value
-      temp = (measurements.getFloat(Measurements::Temperature, false, 1) +
-              measurements.getFloat(Measurements::Temperature, false, 2)) /
+      temp = (measurements.getFloat(Measurements::Temperature, 1) +
+              measurements.getFloat(Measurements::Temperature, 2)) /
              2.0f;
-      hum = (measurements.getFloat(Measurements::Humidity, false, 1) +
-             measurements.getFloat(Measurements::Humidity, false, 2)) /
+      hum = (measurements.getFloat(Measurements::Humidity, 1) +
+             measurements.getFloat(Measurements::Humidity, 2)) /
             2.0f;
     } else if (newPMS1Value) {
       // Only PMS1 has new valid value
-      temp = measurements.getFloat(Measurements::Temperature, false, 1);
-      hum = measurements.getFloat(Measurements::Humidity, false, 1);
+      temp = measurements.getFloat(Measurements::Temperature, 1);
+      hum = measurements.getFloat(Measurements::Humidity, 1);
     } else {
       // Only PMS2 has new valid value
-      temp = measurements.getFloat(Measurements::Temperature, false, 2);
-      hum = measurements.getFloat(Measurements::Humidity, false, 2);
+      temp = measurements.getFloat(Measurements::Temperature, 2);
+      hum = measurements.getFloat(Measurements::Humidity, 2);
     }
 
     // Update compensation temperature and humidity for SGP41

--- a/examples/OneOpenAir/OpenMetrics.cpp
+++ b/examples/OneOpenAir/OpenMetrics.cpp
@@ -74,50 +74,46 @@ String OpenMetrics::getPayload(void) {
   int atmpCompensated = utils::getInvalidTemperature();
   int ahumCompensated = utils::getInvalidHumidity();
   if (config.hasSensorPMS1 && config.hasSensorPMS2) {
-    _temp = (measure.getFloat(Measurements::Temperature, false, 1) +
-             measure.getFloat(Measurements::Temperature, false, 2)) /
+    _temp = (measure.getFloat(Measurements::Temperature, 1) +
+             measure.getFloat(Measurements::Temperature, 2)) /
             2.0f;
-    _hum = (measure.getFloat(Measurements::Humidity, false, 1) +
-            measure.getFloat(Measurements::Humidity, false, 2)) /
+    _hum = (measure.getFloat(Measurements::Humidity, 1) +
+            measure.getFloat(Measurements::Humidity, 2)) /
            2.0f;
-    pm01 = (measure.get(Measurements::PM01, false, 1) + measure.get(Measurements::PM01, false, 2)) /
-           2.0f;
-    pm25 = (measure.get(Measurements::PM25, false, 1) + measure.get(Measurements::PM25, false, 2)) /
-           2.0f;
-    pm10 = (measure.get(Measurements::PM10, false, 1) + measure.get(Measurements::PM10, false, 2)) /
-           2.0f;
-    pm03PCount = (measure.get(Measurements::PM03_PC, false, 1) +
-                  measure.get(Measurements::PM03_PC, false, 2)) /
-                 2.0f;
+    pm01 = (measure.get(Measurements::PM01, 1) + measure.get(Measurements::PM01, 2)) / 2.0f;
+    pm25 = (measure.get(Measurements::PM25, 1) + measure.get(Measurements::PM25, 2)) / 2.0f;
+    pm10 = (measure.get(Measurements::PM10, 1) + measure.get(Measurements::PM10, 2)) / 2.0f;
+    pm03PCount =
+        (measure.get(Measurements::PM03_PC, 1) + measure.get(Measurements::PM03_PC, 2)) / 2.0f;
   } else {
     if (ag->isOne()) {
       if (config.hasSensorSHT) {
-        _temp = measure.getFloat(Measurements::Temperature, false);
-        _hum = measure.getFloat(Measurements::Humidity, false);
+        _temp = measure.getFloat(Measurements::Temperature);
+        _hum = measure.getFloat(Measurements::Humidity);
       }
 
       if (config.hasSensorPMS1) {
-        pm01 = measure.get(Measurements::PM01, false);
-        pm25 = measure.get(Measurements::PM25, false);
-        pm10 = measure.get(Measurements::PM10, false);
-        pm03PCount = measure.get(Measurements::PM03_PC, false);
+        pm01 = measure.get(Measurements::PM01);
+        pm25 = measure.get(Measurements::PM25);
+        pm10 = measure.get(Measurements::PM10);
+        pm03PCount = measure.get(Measurements::PM03_PC);
       }
     } else {
       if (config.hasSensorPMS1) {
-        _temp = measure.getFloat(Measurements::Temperature, false);
-        _hum = measure.getFloat(Measurements::Humidity, false);
-        pm01 = measure.get(Measurements::PM01, false);
-        pm25 = measure.get(Measurements::PM25, false);
-        pm10 = measure.get(Measurements::PM10, false);
-        pm03PCount = measure.get(Measurements::PM03_PC, false);
+        _temp = measure.getFloat(Measurements::Temperature, 1);
+        _hum = measure.getFloat(Measurements::Humidity, 1);
+        pm01 = measure.get(Measurements::PM01, 1);
+        pm25 = measure.get(Measurements::PM25, 1);
+        pm10 = measure.get(Measurements::PM10, 1);
+        pm03PCount = measure.get(Measurements::PM03_PC, 1);
       }
       if (config.hasSensorPMS2) {
-        _temp = measure.getFloat(Measurements::Temperature, false, 2);
-        _hum = measure.getFloat(Measurements::Humidity, false, 2);
-        pm01 = measure.get(Measurements::PM01, false, 2);
-        pm25 = measure.get(Measurements::PM25, false, 2);
-        pm10 = measure.get(Measurements::PM10, false, 2);
-        pm03PCount = measure.get(Measurements::PM03_PC, false, 2);
+        _temp = measure.getFloat(Measurements::Temperature, 2);
+        _hum = measure.getFloat(Measurements::Humidity, 2);
+        pm01 = measure.get(Measurements::PM01, 2);
+        pm25 = measure.get(Measurements::PM25, 2);
+        pm10 = measure.get(Measurements::PM10, 2);
+        pm03PCount = measure.get(Measurements::PM03_PC, 2);
       }
     }
   }

--- a/examples/OneOpenAir/OpenMetrics.cpp
+++ b/examples/OneOpenAir/OpenMetrics.cpp
@@ -74,41 +74,50 @@ String OpenMetrics::getPayload(void) {
   int atmpCompensated = utils::getInvalidTemperature();
   int ahumCompensated = utils::getInvalidHumidity();
   if (config.hasSensorPMS1 && config.hasSensorPMS2) {
-    _temp = (measure.temp_1 + measure.temp_2) / 2.0f;
-    _hum = (measure.hum_1 + measure.hum_2) / 2.0f;
-    pm01 = (measure.pm01_1 + measure.pm01_2) / 2;
-    pm25 = (measure.pm25_1 + measure.pm25_2) / 2;
-    pm10 = (measure.pm10_1 + measure.pm10_2) / 2;
-    pm03PCount = (measure.pm03PCount_1 + measure.pm03PCount_2) / 2;
+    _temp = (measure.getFloat(Measurements::Temperature, false, 1) +
+             measure.getFloat(Measurements::Temperature, false, 2)) /
+            2.0f;
+    _hum = (measure.getFloat(Measurements::Humidity, false, 1) +
+            measure.getFloat(Measurements::Humidity, false, 2)) /
+           2.0f;
+    pm01 = (measure.get(Measurements::PM01, false, 1) + measure.get(Measurements::PM01, false, 2)) /
+           2.0f;
+    pm25 = (measure.get(Measurements::PM25, false, 1) + measure.get(Measurements::PM25, false, 2)) /
+           2.0f;
+    pm10 = (measure.get(Measurements::PM10, false, 1) + measure.get(Measurements::PM10, false, 2)) /
+           2.0f;
+    pm03PCount = (measure.get(Measurements::PM03_PC, false, 1) +
+                  measure.get(Measurements::PM03_PC, false, 2)) /
+                 2.0f;
   } else {
     if (ag->isOne()) {
       if (config.hasSensorSHT) {
-        _temp = measure.Temperature;
-        _hum = measure.Humidity;
+        _temp = measure.getFloat(Measurements::Temperature, false);
+        _hum = measure.getFloat(Measurements::Humidity, false);
       }
 
       if (config.hasSensorPMS1) {
-        pm01 = measure.pm01_1;
-        pm25 = measure.pm25_1;
-        pm10 = measure.pm10_1;
-        pm03PCount = measure.pm03PCount_1;
+        pm01 = measure.get(Measurements::PM01, false);
+        pm25 = measure.get(Measurements::PM25, false);
+        pm10 = measure.get(Measurements::PM10, false);
+        pm03PCount = measure.get(Measurements::PM03_PC, false);
       }
     } else {
       if (config.hasSensorPMS1) {
-        _temp = measure.temp_1;
-        _hum = measure.hum_1;
-        pm01 = measure.pm01_1;
-        pm25 = measure.pm25_1;
-        pm10 = measure.pm10_1;
-        pm03PCount = measure.pm03PCount_1;
+        _temp = measure.getFloat(Measurements::Temperature, false);
+        _hum = measure.getFloat(Measurements::Humidity, false);
+        pm01 = measure.get(Measurements::PM01, false);
+        pm25 = measure.get(Measurements::PM25, false);
+        pm10 = measure.get(Measurements::PM10, false);
+        pm03PCount = measure.get(Measurements::PM03_PC, false);
       }
       if (config.hasSensorPMS2) {
-        _temp = measure.temp_2;
-        _hum = measure.hum_2;
-        pm01 = measure.pm01_2;
-        pm25 = measure.pm25_2;
-        pm10 = measure.pm10_2;
-        pm03PCount = measure.pm03PCount_2;
+        _temp = measure.getFloat(Measurements::Temperature, false, 2);
+        _hum = measure.getFloat(Measurements::Humidity, false, 2);
+        pm01 = measure.get(Measurements::PM01, false, 2);
+        pm25 = measure.get(Measurements::PM25, false, 2);
+        pm10 = measure.get(Measurements::PM10, false, 2);
+        pm03PCount = measure.get(Measurements::PM03_PC, false, 2);
       }
     }
   }

--- a/src/AgOledDisplay.cpp
+++ b/src/AgOledDisplay.cpp
@@ -12,7 +12,7 @@
  */
 void OledDisplay::showTempHum(bool hasStatus, char *buf, int buf_size) {
   /** Temperature */
-  float temp = value.getFloat(Measurements::Temperature, false);
+  float temp = value.getFloat(Measurements::Temperature);
   if (utils::isValidTemperature(temp)) {
     float t = 0.0f;
     if (config.isTemperatureUnitInF()) {
@@ -44,7 +44,7 @@ void OledDisplay::showTempHum(bool hasStatus, char *buf, int buf_size) {
   DISP()->drawUTF8(1, 10, buf);
 
   /** Show humidity */
-  int rhum = (int)value.getFloat(Measurements::Humidity, false);
+  int rhum = (int)value.getFloat(Measurements::Humidity);
   if (utils::isValidHumidity(rhum)) {
     snprintf(buf, buf_size, "%d%%", rhum);
   } else {
@@ -292,7 +292,7 @@ void OledDisplay::showDashboard(const char *status) {
       DISP()->drawUTF8(1, 27, "CO2");
 
       DISP()->setFont(u8g2_font_t0_22b_tf);
-      int co2 = value.get(Measurements::CO2, false);
+      int co2 = value.get(Measurements::CO2);
       if (utils::isValidCO2(co2)) {
         sprintf(strBuf, "%d", co2);
       } else {
@@ -313,11 +313,11 @@ void OledDisplay::showDashboard(const char *status) {
       DISP()->drawStr(55, 27, "PM2.5");
 
       /** Draw PM2.5 value */
-      int pm25 = value.get(Measurements::PM25, false);
+      int pm25 = value.get(Measurements::PM25);
       if (utils::isValidPm(pm25)) {
         /** Compensate PM2.5 value. */
         if (config.hasSensorSHT && config.isMonitorDisplayCompensatedValues()) {
-          pm25 = ag->pms5003.compensate(pm25, value.getFloat(Measurements::Humidity, false));
+          pm25 = ag->pms5003.compensate(pm25, value.getFloat(Measurements::Humidity));
           logInfo("PM2.5 compensate: " + String(pm25));
         }
 
@@ -345,7 +345,7 @@ void OledDisplay::showDashboard(const char *status) {
       DISP()->drawStr(100, 27, "VOC:");
 
       /** Draw tvocIndexvalue */
-      int tvoc = value.get(Measurements::TVOC, false);
+      int tvoc = value.get(Measurements::TVOC);
       if (utils::isValidVOC(tvoc)) {
         sprintf(strBuf, "%d", tvoc);
       } else {
@@ -354,7 +354,7 @@ void OledDisplay::showDashboard(const char *status) {
       DISP()->drawStr(100, 39, strBuf);
 
       /** Draw NOx label */
-      int nox = value.get(Measurements::NOx, false);
+      int nox = value.get(Measurements::NOx);
       DISP()->drawStr(100, 53, "NOx:");
       if (utils::isValidNOx(nox)) {
         sprintf(strBuf, "%d", nox);
@@ -367,7 +367,7 @@ void OledDisplay::showDashboard(const char *status) {
     ag->display.clear();
 
     /** Set CO2 */
-    int co2 = value.get(Measurements::CO2, false);
+    int co2 = value.get(Measurements::CO2);
     if (utils::isValidCO2(co2)) {
       snprintf(strBuf, sizeof(strBuf), "CO2:%d", co2);
     } else {
@@ -378,9 +378,9 @@ void OledDisplay::showDashboard(const char *status) {
     ag->display.setText(strBuf);
 
     /** Set PM */
-    int pm25 = value.get(Measurements::PM25, false);
+    int pm25 = value.get(Measurements::PM25);
     if (config.hasSensorSHT && config.isMonitorDisplayCompensatedValues()) {
-      pm25 = (int)ag->pms5003.compensate(pm25, value.getFloat(Measurements::Humidity, false));
+      pm25 = (int)ag->pms5003.compensate(pm25, value.getFloat(Measurements::Humidity));
     }
 
     ag->display.setCursor(0, 12);
@@ -392,7 +392,7 @@ void OledDisplay::showDashboard(const char *status) {
     ag->display.setText(strBuf);
 
     /** Set temperature and humidity */
-    float temp = value.getFloat(Measurements::Temperature, false);
+    float temp = value.getFloat(Measurements::Temperature);
     if (utils::isValidTemperature(temp)) {
       if (config.isTemperatureUnitInF()) {
         snprintf(strBuf, sizeof(strBuf), "T:%0.1f F", utils::degreeC_To_F(temp));
@@ -410,7 +410,7 @@ void OledDisplay::showDashboard(const char *status) {
     ag->display.setCursor(0, 24);
     ag->display.setText(strBuf);
 
-    int rhum = (int)value.getFloat(Measurements::Humidity, false);
+    int rhum = (int)value.getFloat(Measurements::Humidity);
     if (utils::isValidHumidity(rhum)) {
       snprintf(strBuf, sizeof(strBuf), "H:%d %%", rhum);
     } else {

--- a/src/AgStateMachine.cpp
+++ b/src/AgStateMachine.cpp
@@ -69,7 +69,7 @@ void StateMachine::sensorhandleLeds(void) {
  *
  */
 void StateMachine::co2handleLeds(void) {
-  int co2Value = value.get(Measurements::CO2, false);
+  int co2Value = value.get(Measurements::CO2);
   if (co2Value <= 600) {
     /** G; 1 */
     ag->ledBar.setColor(RGB_COLOR_G, ag->ledBar.getNumberOfLeds() - 1);
@@ -141,9 +141,9 @@ void StateMachine::co2handleLeds(void) {
  *
  */
 void StateMachine::pm25handleLeds(void) {
-  int pm25Value = value.get(Measurements::PM25, false);
+  int pm25Value = value.get(Measurements::PM25);
   if (config.isMonitorDisplayCompensatedValues() && config.hasSensorSHT) {
-    pm25Value = ag->pms5003.compensate(pm25Value, value.getFloat(Measurements::Humidity, false));
+    pm25Value = ag->pms5003.compensate(pm25Value, value.getFloat(Measurements::Humidity));
   }
 
   if (pm25Value < 5) {

--- a/src/AgStateMachine.cpp
+++ b/src/AgStateMachine.cpp
@@ -69,7 +69,7 @@ void StateMachine::sensorhandleLeds(void) {
  *
  */
 void StateMachine::co2handleLeds(void) {
-  int co2Value = value.CO2;
+  int co2Value = value.get(Measurements::CO2, false);
   if (co2Value <= 600) {
     /** G; 1 */
     ag->ledBar.setColor(RGB_COLOR_G, ag->ledBar.getNumberOfLeds() - 1);
@@ -141,9 +141,9 @@ void StateMachine::co2handleLeds(void) {
  *
  */
 void StateMachine::pm25handleLeds(void) {
-  int pm25Value = value.pm25_1;
+  int pm25Value = value.get(Measurements::PM25, false);
   if (config.isMonitorDisplayCompensatedValues() && config.hasSensorSHT) {
-    pm25Value = ag->pms5003.compensate(value.pm25_1, value.Humidity);
+    pm25Value = ag->pms5003.compensate(pm25Value, value.getFloat(Measurements::Humidity, false));
   }
 
   if (pm25Value < 5) {

--- a/src/AgValue.cpp
+++ b/src/AgValue.cpp
@@ -79,7 +79,7 @@ String Measurements::agValueTypeStr(AgValueType type) {
   return str;
 }
 
-void Measurements::updateValue(AgValueType type, int val) {
+bool Measurements::updateValue(AgValueType type, int val) {
   // Define data point source
   IntegerValue *temporary = nullptr;
   float invalidValue = 0;
@@ -135,32 +135,35 @@ void Measurements::updateValue(AgValueType type, int val) {
   if (val != invalidValue) {
     temporary->lastValue = val;
     temporary->sumValues = temporary->sumValues + val;
-    temporary->read.success = temporary->read.success + 1;
+    temporary->update.success = temporary->update.success + 1;
   }
 
-  // Increment read counter
-  temporary->read.counter = temporary->read.counter + 1;
+  // Increment update.counter
+  temporary->update.counter = temporary->update.counter + 1;
 
   // Calculate value average when maximum set is reached
-  if (temporary->read.counter >= temporary->read.max) {
+  if (temporary->update.counter >= temporary->update.max) {
     // Calculate the average
-    temporary->avg = temporary->sumValues / temporary->read.success;
+    temporary->avg = temporary->sumValues / temporary->update.success;
 
     // This is just for notifying
-    int miss = temporary->read.max - temporary->read.success;
+    int miss = temporary->update.max - temporary->update.success;
     if (miss != 0) {
-      Serial.printf("%s reading miss %d out of %d update\n", agValueTypeStr(type), miss,
-                    temporary->read.max);
+      Serial.printf("%s update.ng miss %d out of %d update\n", agValueTypeStr(type), miss,
+                    temporary->update.max);
     }
 
-    // Resets the sum data and read variables
+    // Resets average related variable calculation
     temporary->sumValues = 0;
-    temporary->read.counter = 0;
-    temporary->read.success = 0;
+    temporary->update.counter = 0;
+    temporary->update.success = 0;
+    return true;
   }
+
+  return false;
 }
 
-void Measurements::updateValue(AgValueType type, float val) {
+bool Measurements::updateValue(AgValueType type, float val) {
   // Define data point source
   FloatValue *temporary = nullptr;
   float invalidValue = 0;
@@ -188,29 +191,32 @@ void Measurements::updateValue(AgValueType type, float val) {
   if (val != invalidValue) {
     temporary->lastValue = val;
     temporary->sumValues = temporary->sumValues + val;
-    temporary->read.success = temporary->read.success + 1;
+    temporary->update.success = temporary->update.success + 1;
   }
 
-  // Increment read counter
-  temporary->read.counter = temporary->read.counter + 1;
+  // Increment update.counter
+  temporary->update.counter = temporary->update.counter + 1;
 
   // Calculate value average when maximum set is reached
-  if (temporary->read.counter >= temporary->read.max) {
+  if (temporary->update.counter >= temporary->update.max) {
     // Calculate the average
-    temporary->avg = temporary->sumValues / temporary->read.success;
+    temporary->avg = temporary->sumValues / temporary->update.success;
 
     // This is just for notifying
-    int miss = temporary->read.max - temporary->read.success;
+    int miss = temporary->update.max - temporary->update.success;
     if (miss != 0) {
-      Serial.printf("%s reading miss %d out of %d update\n", agValueTypeStr(type), miss,
-                    temporary->read.max);
+      Serial.printf("%s update.ng miss %d out of %d update\n", agValueTypeStr(type), miss,
+                    temporary->update.max);
     }
 
-    // Resets the sum data and read variables
+    // Resets average related variable calculation
     temporary->sumValues = 0;
-    temporary->read.counter = 0;
-    temporary->read.success = 0;
+    temporary->update.counter = 0;
+    temporary->update.success = 0;
+    return true;
   }
+
+  return false;
 }
 
 String Measurements::toString(bool localServer, AgFirmwareMode fwMode, int rssi,

--- a/src/AgValue.cpp
+++ b/src/AgValue.cpp
@@ -111,9 +111,16 @@ bool Measurements::update(MeasurementType type, int val, int ch) {
 
   if (val == invalidValue) {
     temporary->update.invalidCounter++;
-    // TODO: Need to check if its more than threshold, to create some indication. Maybe reference to
-    // max element?
-    return false;
+    if (temporary->update.invalidCounter >= temporary->update.max) {
+      Serial.printf("%s{%d} invalid value update counter reached (%dx)! Setting its average value "
+                    "to invalid!",
+                    measurementTypeStr(type), ch, temporary->update.max);
+      temporary->update.avg = invalidValue;
+      return false;
+    }
+
+    // Still consider updating value to valid
+    return true;
   }
 
   // Reset invalid counter when update new valid value
@@ -174,9 +181,16 @@ bool Measurements::update(MeasurementType type, float val, int ch) {
 
   if (val == invalidValue) {
     temporary->update.invalidCounter++;
-    // TODO: Need to check if its more than threshold, to create some indication. Maybe reference to
-    // max element?
-    return false;
+    if (temporary->update.invalidCounter >= temporary->update.max) {
+      Serial.printf("%s{%d} invalid value update counter reached (%dx)! Setting its average value "
+                    "to invalid!",
+                    measurementTypeStr(type), ch, temporary->update.max);
+      temporary->update.avg = invalidValue;
+      return false;
+    }
+
+    // Still consider updating value to valid
+    return true;
   }
 
   // Reset invalid counter when update new valid value

--- a/src/AgValue.cpp
+++ b/src/AgValue.cpp
@@ -852,7 +852,7 @@ JSONVar Measurements::buildIndoor(bool localServer, AirGradient &ag, Configurati
     }
     // Add humidity
     if (utils::isValidHumidity(_humidity[0].avg)) {
-      indoor["rhum"] = _humidity[0].avg;
+      indoor["rhum"] = ag.round2(_humidity[0].avg);
       if (localServer) {
         indoor["rhumCompensated"] = ag.round2(_humidity[0].avg);
       }

--- a/src/AgValue.cpp
+++ b/src/AgValue.cpp
@@ -1,55 +1,54 @@
 #include "AgValue.h"
 #include "AgConfigure.h"
 #include "AirGradient.h"
-#include "Libraries/Arduino_JSON/src/Arduino_JSON.h"
 
 #define json_prop_pmFirmware     "firmware"
 
-void Measurements::maxUpdate(AgValueType type, int max) {
+void Measurements::maxUpdate(MeasurementType type, int max) {
   switch (type) {
-  case AgValueType::Temperature:
+  case Temperature:
     _temperature[0].update.max = max;
     _temperature[1].update.max = max;
     break;
-  case AgValueType::Humidity:
+  case Humidity:
     _humidity[0].update.max = max;
     _humidity[1].update.max = max;
     break;
-  case AgValueType::CO2:
+  case CO2:
     _co2.update.max = max;
     break;
-  case AgValueType::TVOC:
+  case TVOC:
     _tvoc.update.max = max;
     break;
-  case AgValueType::TVOCRaw:
+  case TVOCRaw:
     _tvoc_raw.update.max = max;
     break;
-  case AgValueType::NOx:
+  case NOx:
     _nox.update.max = max;
     break;
-  case AgValueType::NOxRaw:
+  case NOxRaw:
     _nox_raw.update.max = max;
     break;
-  case AgValueType::PM25:
+  case PM25:
     _pm_25[0].update.max = max;
     _pm_25[1].update.max = max;
     break;
-  case AgValueType::PM01:
+  case PM01:
     _pm_01[0].update.max = max;
     _pm_01[1].update.max = max;
     break;
-  case AgValueType::PM10:
+  case PM10:
     _pm_10[0].update.max = max;
     _pm_10[1].update.max = max;
     break;
-  case AgValueType::PM03_PC:
+  case PM03_PC:
     _pm_03_pc[0].update.max = max;
     _pm_03_pc[1].update.max = max;
     break;
   };
 }
 
-bool Measurements::updateValue(AgValueType type, int val, int ch) {
+bool Measurements::update(MeasurementType type, int val, int ch) {
   // Sanity check to validate channel, assert if invalid
   validateChannel(ch);
 
@@ -60,39 +59,39 @@ bool Measurements::updateValue(AgValueType type, int val, int ch) {
   IntegerValue *temporary = nullptr;
   float invalidValue = 0;
   switch (type) {
-  case AgValueType::CO2:
+  case CO2:
     temporary = &_co2;
     invalidValue = utils::getInvalidCO2();
     break;
-  case AgValueType::TVOC:
+  case TVOC:
     temporary = &_tvoc;
     invalidValue = utils::getInvalidVOC();
     break;
-  case AgValueType::TVOCRaw:
+  case TVOCRaw:
     temporary = &_tvoc_raw;
     invalidValue = utils::getInvalidVOC();
     break;
-  case AgValueType::NOx:
+  case NOx:
     temporary = &_nox;
     invalidValue = utils::getInvalidNOx();
     break;
-  case AgValueType::NOxRaw:
+  case NOxRaw:
     temporary = &_nox_raw;
     invalidValue = utils::getInvalidNOx();
     break;
-  case AgValueType::PM25:
+  case PM25:
     temporary = &_pm_25[ch];
     invalidValue = utils::getInvalidPmValue();
     break;
-  case AgValueType::PM01:
+  case PM01:
     temporary = &_pm_01[ch];
     invalidValue = utils::getInvalidPmValue();
     break;
-  case AgValueType::PM10:
+  case PM10:
     temporary = &_pm_10[ch];
     invalidValue = utils::getInvalidPmValue();
     break;
-  case AgValueType::PM03_PC:
+  case PM03_PC:
     temporary = &_pm_03_pc[ch];
     invalidValue = utils::getInvalidPmValue();
     break;
@@ -100,9 +99,9 @@ bool Measurements::updateValue(AgValueType type, int val, int ch) {
     break;
   };
 
-  // Sanity check if agvaluetype is defined for integer data type or not
+  // Sanity check if measurement type is defined for integer data type or not
   if (temporary == nullptr) {
-    Serial.printf("%s is not defined for integer data type\n", agValueTypeStr(type));
+    Serial.printf("%s is not defined for integer data type\n", measurementTypeStr(type));
     // TODO: Just assert?
     return false;
   }
@@ -125,13 +124,13 @@ bool Measurements::updateValue(AgValueType type, int val, int ch) {
     // TODO: Need to check if SUCCESS == 0, what should we do?
     // Calculate the average
     temporary->avg = temporary->sumValues / temporary->update.success;
-    Serial.printf("%s{%d} count reached! Average value %d\n", agValueTypeStr(type), ch,
+    Serial.printf("%s{%d} count reached! Average value %d\n", measurementTypeStr(type), ch,
                   temporary->avg);
 
     // Notify if there's are invalid value when updating
     int miss = temporary->update.max - temporary->update.success;
     if (miss != 0) {
-      Serial.printf("%s{%d} has %d invalid value out of %d update\n", agValueTypeStr(type), ch,
+      Serial.printf("%s{%d} has %d invalid value out of %d update\n", measurementTypeStr(type), ch,
                     miss, temporary->update.max);
     }
 
@@ -145,7 +144,7 @@ bool Measurements::updateValue(AgValueType type, int val, int ch) {
   return false;
 }
 
-bool Measurements::updateValue(AgValueType type, float val, int ch) {
+bool Measurements::update(MeasurementType type, float val, int ch) {
   // Sanity check to validate channel, assert if invalid
   validateChannel(ch);
 
@@ -156,11 +155,11 @@ bool Measurements::updateValue(AgValueType type, float val, int ch) {
   FloatValue *temporary = nullptr;
   float invalidValue = 0;
   switch (type) {
-  case AgValueType::Temperature:
+  case Temperature:
     temporary = &_temperature[ch];
     invalidValue = utils::getInvalidTemperature();
     break;
-  case AgValueType::Humidity:
+  case Humidity:
     temporary = &_humidity[ch];
     invalidValue = utils::getInvalidHumidity();
     break;
@@ -168,9 +167,9 @@ bool Measurements::updateValue(AgValueType type, float val, int ch) {
     break;
   }
 
-  // Sanity check if agvaluetype is defined for float data type or not
+  // Sanity check if measurement type is defined for float data type or not
   if (temporary == nullptr) {
-    Serial.printf("%s is not defined for float data type\n", agValueTypeStr(type));
+    Serial.printf("%s is not defined for float data type\n", measurementTypeStr(type));
     // TODO: Just assert?
     return false;
   }
@@ -193,13 +192,13 @@ bool Measurements::updateValue(AgValueType type, float val, int ch) {
     // TODO: Need to check if SUCCESS == 0
     // Calculate the average
     temporary->avg = temporary->sumValues / temporary->update.success;
-    Serial.printf("%s{%d} count reached! Average value %0.2f\n", agValueTypeStr(type), ch,
+    Serial.printf("%s{%d} count reached! Average value %0.2f\n", measurementTypeStr(type), ch,
                   temporary->avg);
 
     // This is just for notifying
     int miss = temporary->update.max - temporary->update.success;
     if (miss != 0) {
-      Serial.printf("%s{%d} has %d invalid value out of %d update\n", agValueTypeStr(type), ch,
+      Serial.printf("%s{%d} has %d invalid value out of %d update\n", measurementTypeStr(type), ch,
                     miss, temporary->update.max);
     }
 
@@ -213,7 +212,7 @@ bool Measurements::updateValue(AgValueType type, float val, int ch) {
   return false;
 }
 
-int Measurements::getValue(AgValueType type, bool average, int ch) {
+int Measurements::get(MeasurementType type, bool average, int ch) {
   // Sanity check to validate channel, assert if invalid
   validateChannel(ch);
 
@@ -224,40 +223,40 @@ int Measurements::getValue(AgValueType type, bool average, int ch) {
   IntegerValue *temporary = nullptr;
   float invalidValue = 0;
   switch (type) {
-  case AgValueType::CO2:
+  case CO2:
     temporary = &_co2;
     break;
-  case AgValueType::TVOC:
+  case TVOC:
     temporary = &_tvoc;
     break;
-  case AgValueType::TVOCRaw:
+  case TVOCRaw:
     temporary = &_tvoc_raw;
     break;
-  case AgValueType::NOx:
+  case NOx:
     temporary = &_nox;
     break;
-  case AgValueType::NOxRaw:
+  case NOxRaw:
     temporary = &_nox_raw;
     break;
-  case AgValueType::PM25:
+  case PM25:
     temporary = &_pm_25[ch];
     break;
-  case AgValueType::PM01:
+  case PM01:
     temporary = &_pm_01[ch];
     break;
-  case AgValueType::PM10:
+  case PM10:
     temporary = &_pm_10[ch];
     break;
-  case AgValueType::PM03_PC:
+  case PM03_PC:
     temporary = &_pm_03_pc[ch];
     break;
   default:
     break;
   };
 
-  // Sanity check if agvaluetype is defined for integer data type or not
+  // Sanity check if measurement type is defined for integer data type or not
   if (temporary == nullptr) {
-    Serial.printf("%s is not defined for integer data type\n", agValueTypeStr(type));
+    Serial.printf("%s is not defined for integer data type\n", measurementTypeStr(type));
     // TODO: Just assert?
     return false;
   }
@@ -269,26 +268,29 @@ int Measurements::getValue(AgValueType type, bool average, int ch) {
   return temporary->lastValue;
 }
 
-float Measurements::getValueFloat(AgValueType type, bool average, int ch) {
+float Measurements::getFloat(MeasurementType type, bool average, int ch) {
   // Sanity check to validate channel, assert if invalid
   validateChannel(ch);
+
+  // Follow array indexing just for get address of the value type
+  ch = ch - 1;
 
   // Define data point source
   FloatValue *temporary = nullptr;
   switch (type) {
-  case AgValueType::Temperature:
+  case Temperature:
     temporary = &_temperature[ch];
     break;
-  case AgValueType::Humidity:
+  case Humidity:
     temporary = &_humidity[ch];
     break;
   default:
     break;
   }
 
-  // Sanity check if agvaluetype is defined for float data type or not
+  // Sanity check if measurement type is defined for float data type or not
   if (temporary == nullptr) {
-    Serial.printf("%s is not defined for float data type\n", agValueTypeStr(type));
+    Serial.printf("%s is not defined for float data type\n", measurementTypeStr(type));
     // TODO: Just assert?
     return false;
   }
@@ -298,382 +300,6 @@ float Measurements::getValueFloat(AgValueType type, bool average, int ch) {
   }
 
   return temporary->lastValue;
-}
-
-String Measurements::toString(bool localServer, AgFirmwareMode fwMode, int rssi, void *_ag,
-                              void *_config) {
-  AirGradient *ag = (AirGradient *)_ag;
-  Configuration *config = (Configuration *)_config;
-
-  JSONVar root;
-  root["wifi"] = rssi;
-  if (localServer) {
-    root["serialno"] = ag->deviceId();
-  }
-
-  if (config->hasSensorS8 && utils::isValidCO2(this->CO2)) {
-    root["rco2"] = this->CO2;
-  }
-
-  if (ag->isOne() || (ag->isPro4_2()) || ag->isPro3_3() || ag->isBasic()) {
-    if (config->hasSensorPMS1) {
-      if (utils::isValidPm(this->pm01_1)) {
-        root["pm01"] = this->pm01_1;
-      }
-      if (utils::isValidPm(this->pm25_1)) {
-        root["pm02"] = this->pm25_1;
-      }
-      if (utils::isValidPm(this->pm10_1)) {
-        root["pm10"] = this->pm10_1;
-      }
-      if (utils::isValidPm03Count(this->pm03PCount_1)) {
-        root["pm003Count"] = this->pm03PCount_1;
-      }
-      if (!localServer) {
-
-        root[json_prop_pmFirmware] =
-            this->pms5003FirmwareVersion(ag->pms5003.getFirmwareVersion());
-      }
-    }
-
-    if (config->hasSensorSHT) {
-      if (utils::isValidTemperature(this->Temperature)) {
-        root["atmp"] = ag->round2(this->Temperature);
-        if (localServer) {
-          root["atmpCompensated"] = ag->round2(this->Temperature);
-        }
-      }
-      if (utils::isValidHumidity(this->Humidity)) {
-        root["rhum"] = this->Humidity;
-        if (localServer) {
-          root["rhumCompensated"] = this->Humidity;
-        }
-      }
-    }
-
-    if (config->hasSensorSHT && config->hasSensorPMS1) {
-      int pm25 = ag->pms5003.compensate(this->pm25_1, this->Humidity);
-      if (pm25 >= 0) {
-        root["pm02Compensated"] = pm25;
-      }
-    }
-
-  } else {
-    if (config->hasSensorPMS1 && config->hasSensorPMS2) {
-      if (utils::isValidPm(this->pm01_1) && utils::isValidPm(this->pm01_2)) {
-        root["pm01"] = ag->round2((this->pm01_1 + this->pm01_2) / 2.0f);
-      }
-      if (utils::isValidPm(this->pm25_1) && utils::isValidPm(this->pm25_2)) {
-        root["pm02"] = ag->round2((this->pm25_1 + this->pm25_2) / 2.0f);
-      }
-      if (utils::isValidPm(this->pm10_1) && utils::isValidPm(this->pm10_2)) {
-        root["pm10"] = ag->round2((this->pm10_1 + this->pm10_2) / 2.0f);
-      }
-      if (utils::isValidPm(this->pm03PCount_1) && utils::isValidPm(this->pm03PCount_2)) {
-        root["pm003Count"] = ag->round2((this->pm03PCount_1 + this->pm03PCount_2) / 2.0f);
-      }
-
-      float val;
-      if (utils::isValidTemperature(this->temp_1) && utils::isValidTemperature(this->temp_1)) {
-        root["atmp"] = ag->round2((this->temp_1 + this->temp_2) / 2.0f);
-        if (localServer) {
-          val = ag->pms5003t_2.compensateTemp((this->temp_1 + this->temp_2) / 2.0f);
-          if (utils::isValidTemperature(val)) {
-            root["atmpCompensated"] = ag->round2(val);
-          }
-        }
-      }
-      if (utils::isValidHumidity(this->hum_1) && utils::isValidHumidity(this->hum_1)) {
-        root["rhum"] = ag->round2((this->hum_1 + this->hum_2) / 2.0f);
-        if (localServer) {
-          val = ag->pms5003t_2.compensateHum((this->hum_1 + this->hum_2) / 2.0f);
-          if (utils::isValidHumidity(val)) {
-            root["rhumCompensated"] = (int)val;
-          }
-        }
-      }
-
-      int pm25 = (ag->pms5003t_1.compensate(this->pm25_1, this->hum_1) +
-                  ag->pms5003t_2.compensate(this->pm25_2, this->hum_2)) /
-                 2;
-      root["pm02Compensated"] = pm25;
-    }
-
-    if (fwMode == FW_MODE_O_1PS || fwMode == FW_MODE_O_1PST) {
-      float val;
-      if (config->hasSensorPMS1) {
-        if (utils::isValidPm(this->pm01_1)) {
-          root["pm01"] = this->pm01_1;
-        }
-        if (utils::isValidPm(this->pm25_1)) {
-          root["pm02"] = this->pm25_1;
-        }
-        if (utils::isValidPm(this->pm10_1)) {
-          root["pm10"] = this->pm10_1;
-        }
-        if (utils::isValidPm03Count(this->pm03PCount_1)) {
-          root["pm003Count"] = this->pm03PCount_1;
-        }
-        if (utils::isValidTemperature(this->temp_1)) {
-          root["atmp"] = ag->round2(this->temp_1);
-
-          if (localServer) {
-            val = ag->pms5003t_1.compensateTemp(this->temp_1);
-            if (utils::isValidTemperature(val)) {
-              root["atmpCompensated"] = ag->round2(val);
-            }
-          }
-        }
-        if (utils::isValidHumidity(this->hum_1)) {
-          root["rhum"] = this->hum_1;
-
-          if (localServer) {
-            val = ag->pms5003t_1.compensateHum(this->hum_1);
-            if (utils::isValidHumidity(val)) {
-              root["rhumCompensated"] = (int)val;
-            }
-          }
-        }
-        root["pm02Compensated"] = ag->pms5003t_1.compensate(this->pm25_1, this->hum_1);
-        if (!localServer) {
-          root[json_prop_pmFirmware] =
-              pms5003TFirmwareVersion(ag->pms5003t_1.getFirmwareVersion());
-        }
-      }
-      if (config->hasSensorPMS2) {
-        if(utils::isValidPm(this->pm01_2)) {
-          root["pm01"] = this->pm01_2;
-        }
-        if(utils::isValidPm(this->pm25_2)) {
-          root["pm02"] = this->pm25_2;
-        }
-        if(utils::isValidPm(this->pm10_2)) {
-          root["pm10"] = this->pm10_2;
-        }
-        if(utils::isValidPm03Count(this->pm03PCount_2)) {
-          root["pm003Count"] = this->pm03PCount_2;
-        }
-
-        float val;
-        if (utils::isValidTemperature(this->temp_2)) {
-          root["atmp"] = ag->round2(this->temp_2);
-
-          if (localServer) {
-            val = ag->pms5003t_2.compensateTemp(this->temp_2);
-            if (utils::isValidTemperature(val)) {
-              root["atmpCompensated"] = ag->round2(val);
-            }
-          }
-        }
-        if(utils::isValidHumidity(this->hum_2)) {
-          root["rhum"] = this->hum_2;
-
-          if (localServer) {
-            val = ag->pms5003t_2.compensateHum(this->hum_2);
-            if (utils::isValidHumidity(val)) {
-              root["rhumCompensated"] = (int)val;
-            }
-          }
-        }
-        root["pm02Compensated"] = ag->pms5003t_2.compensate(this->pm25_2, this->hum_2);
-        if(!localServer) {
-          root[json_prop_pmFirmware] =
-              pms5003TFirmwareVersion(ag->pms5003t_1.getFirmwareVersion());
-        }
-      }
-    } else {
-      if (fwMode == FW_MODE_O_1P) {
-        float val;
-        if (config->hasSensorPMS1) {
-          if (utils::isValidPm(this->pm01_1)) {
-            root["pm01"] = this->pm01_1;
-          }
-          if (utils::isValidPm(this->pm25_1)) {
-            root["pm02"] = this->pm25_1;
-          }
-          if (utils::isValidPm(this->pm10_1)) {
-            root["pm10"] = this->pm10_1;
-          }
-          if (utils::isValidPm03Count(this->pm03PCount_1)) {
-            root["pm003Count"] = this->pm03PCount_1;
-          }
-          if (utils::isValidTemperature(this->temp_1)) {
-            root["atmp"] = ag->round2(this->temp_1);
-
-            if (localServer) {
-              val = ag->pms5003t_1.compensateTemp(this->temp_1);
-              if (utils::isValidTemperature(val)) {
-                root["atmpCompensated"] = ag->round2(val);
-              }
-            }
-          }
-          if (utils::isValidHumidity(this->hum_1)) {
-            root["rhum"] = this->hum_1;
-            if(localServer) {
-              val = ag->pms5003t_1.compensateHum(this->hum_1);
-              if(utils::isValidHumidity(val)) {
-                root["rhumCompensated"] = (int)val;
-              }
-            }
-          }
-          root["pm02Compensated"] = ag->pms5003t_1.compensate(this->pm25_1, this->hum_1);
-          if(!localServer) {
-            root[json_prop_pmFirmware] =
-                pms5003TFirmwareVersion(ag->pms5003t_1.getFirmwareVersion());
-          }
-        } else if (config->hasSensorPMS2) {
-          if(utils::isValidPm(this->pm01_2)) {
-            root["pm01"] = this->pm01_2;
-          }
-          if(utils::isValidPm(this->pm25_2)) {
-            root["pm02"] = this->pm25_2;
-          }
-          if(utils::isValidPm(this->pm10_2)) {
-            root["pm10"] = this->pm10_2;
-          }
-          if(utils::isValidPm03Count(this->pm03PCount_2)) {
-            root["pm003Count"] = this->pm03PCount_2;
-          }
-          if (utils::isValidTemperature(this->temp_2)) {
-            root["atmp"] = ag->round2(this->temp_2);
-            if (localServer) {
-
-              val = ag->pms5003t_1.compensateTemp(this->temp_2);
-              if (utils::isValidTemperature(val)) {
-                root["atmpCompensated"] = ag->round2(val);
-              }
-            }
-          }
-          if (utils::isValidHumidity(this->hum_2)) {
-            root["rhum"] = this->hum_2;
-
-            if(localServer) {
-              val = ag->pms5003t_1.compensateHum(this->hum_2);
-              if(utils::isValidHumidity(val)) {
-                root["rhumCompensated"] = (int)val;
-              }
-            }
-          }
-          root["pm02Compensated"] = ag->pms5003t_1.compensate(this->pm25_1, this->hum_1);
-          if(!localServer) {
-            root[json_prop_pmFirmware] =
-                pms5003TFirmwareVersion(ag->pms5003t_2.getFirmwareVersion());
-          }
-        }
-      } else {
-        float val;
-        if (config->hasSensorPMS1) {
-          if(utils::isValidPm(this->pm01_1)) {
-            root["channels"]["1"]["pm01"] = this->pm01_1;
-          }
-          if(utils::isValidPm(this->pm25_1)) {
-            root["channels"]["1"]["pm02"] = this->pm25_1;
-          }
-          if(utils::isValidPm(this->pm10_1)) {
-            root["channels"]["1"]["pm10"] = this->pm10_1;
-          }
-          if (utils::isValidPm03Count(this->pm03PCount_1)) {
-            root["channels"]["1"]["pm003Count"] = this->pm03PCount_1;
-          }
-          if(utils::isValidTemperature(this->temp_1)) {
-            root["channels"]["1"]["atmp"] = ag->round2(this->temp_1);
-
-            if (localServer) {
-              val = ag->pms5003t_1.compensateTemp(this->temp_1);
-              if (utils::isValidTemperature(val)) {
-                root["channels"]["1"]["atmpCompensated"] = ag->round2(val);
-              }
-            }
-          }
-          if (utils::isValidHumidity(this->hum_1)) {
-            root["channels"]["1"]["rhum"] = this->hum_1;
-
-            if (localServer) {
-              val = ag->pms5003t_1.compensateHum(this->hum_1);
-              if (utils::isValidHumidity(val)) {
-                root["channels"]["1"]["rhumCompensated"] = (int)val;
-              }
-            }
-          }
-          root["channels"]["1"]["pm02Compensated"] = ag->pms5003t_1.compensate(this->pm25_1, this->hum_1);
-        
-          // PMS5003T version
-          if(!localServer) {
-            root["channels"]["1"][json_prop_pmFirmware] =
-                pms5003TFirmwareVersion(ag->pms5003t_1.getFirmwareVersion());
-          }
-        }
-        if (config->hasSensorPMS2) {
-          float val;
-          if (utils::isValidPm(this->pm01_2)) {
-            root["channels"]["2"]["pm01"] = this->pm01_2;
-          }
-          if (utils::isValidPm(this->pm25_2)) {
-            root["channels"]["2"]["pm02"] = this->pm25_2;
-          }
-          if (utils::isValidPm(this->pm10_2)) {
-            root["channels"]["2"]["pm10"] = this->pm10_2;
-          }
-          if (utils::isValidPm03Count(this->pm03PCount_2)) {
-            root["channels"]["2"]["pm003Count"] = this->pm03PCount_2;
-          }
-          if (utils::isValidTemperature(this->temp_2)) {
-            root["channels"]["2"]["atmp"] = ag->round2(this->temp_2);
-
-            if (localServer) {
-              val = ag->pms5003t_1.compensateTemp(this->temp_2);
-              if (utils::isValidTemperature(val)) {
-                root["channels"]["2"]["atmpCompensated"] = ag->round2(val);
-              }
-            }
-          }
-          if (utils::isValidHumidity(this->hum_2)) {
-            root["channels"]["2"]["rhum"] = this->hum_2;
-
-            if (localServer) {
-              val = ag->pms5003t_1.compensateHum(this->hum_2);
-              if (utils::isValidHumidity(val)) {
-                root["channels"]["2"]["rhumCompensated"] = (int)val;
-              }
-            }
-          }
-          root["channels"]["2"]["pm02Compensated"] = ag->pms5003t_2.compensate(this->pm25_2, this->hum_2);
-          // PMS5003T version
-          if(!localServer) {
-            root["channels"]["2"][json_prop_pmFirmware] =
-                pms5003TFirmwareVersion(ag->pms5003t_2.getFirmwareVersion());
-          }
-        }
-      }
-    }
-  }
-
-  if (config->hasSensorSGP) {
-    if (utils::isValidVOC(this->TVOC)) {
-      root["tvocIndex"] = this->TVOC;
-    }
-    if (utils::isValidVOC(this->TVOCRaw)) {
-      root["tvocRaw"] = this->TVOCRaw;
-    }
-    if (utils::isValidNOx(this->NOx)) {
-      root["noxIndex"] = this->NOx;
-    }
-    if (utils::isValidNOx(this->NOxRaw)) {
-      root["noxRaw"] = this->NOxRaw;
-    }
-  }
-  root["boot"] = bootCount;
-  root["bootCount"] = bootCount;
-
-  if (localServer) {
-    if (ag->isOne()) {
-      root["ledMode"] = config->getLedBarModeName();
-    }
-    root["firmware"] = ag->getVersion();
-    root["model"] = AgFirmwareModeName(fwMode);
-  }
-
-  return JSON.stringify(root);
 }
 
 String Measurements::pms5003FirmwareVersion(int fwCode) {
@@ -688,40 +314,40 @@ String Measurements::pms5003FirmwareVersionBase(String prefix, int fwCode) {
   return prefix + String("-") + String(fwCode);
 }
 
-String Measurements::agValueTypeStr(AgValueType type) {
+String Measurements::measurementTypeStr(MeasurementType type) {
   String str;
   switch (type) {
-  case AgValueType::Temperature:
+  case Temperature:
     str = "Temperature";
     break;
-  case AgValueType::Humidity:
+  case Humidity:
     str = "Humidity";
     break;
-  case AgValueType::CO2:
+  case CO2:
     str = "CO2";
     break;
-  case AgValueType::TVOC:
+  case TVOC:
     str = "TVOC";
     break;
-  case AgValueType::TVOCRaw:
+  case TVOCRaw:
     str = "TVOCRaw";
     break;
-  case AgValueType::NOx:
+  case NOx:
     str = "NOx";
     break;
-  case AgValueType::NOxRaw:
+  case NOxRaw:
     str = "NOxRaw";
     break;
-  case AgValueType::PM25:
+  case PM25:
     str = "PM25";
     break;
-  case AgValueType::PM01:
+  case PM01:
     str = "PM01";
     break;
-  case AgValueType::PM10:
+  case PM10:
     str = "PM10";
     break;
-  case AgValueType::PM03_PC:
+  case PM03_PC:
     str = "PM03";
     break;
   default:
@@ -739,8 +365,8 @@ void Measurements::validateChannel(int ch) {
   }
 }
 
-String Measurements::toStringX(bool localServer, AgFirmwareMode fwMode, int rssi, AirGradient &ag,
-                               Configuration &config) {
+String Measurements::toString(bool localServer, AgFirmwareMode fwMode, int rssi, AirGradient &ag,
+                              Configuration &config) {
   JSONVar root;
 
   if (ag.isOne() || (ag.isPro4_2()) || ag.isPro3_3() || ag.isBasic()) {

--- a/src/AgValue.cpp
+++ b/src/AgValue.cpp
@@ -4,7 +4,7 @@
 
 #define json_prop_pmFirmware     "firmware"
 
-void Measurements::maxUpdate(MeasurementType type, int max) {
+void Measurements::maxPeriod(MeasurementType type, int max) {
   switch (type) {
   case Temperature:
     _temperature[0].update.max = max;

--- a/src/AgValue.cpp
+++ b/src/AgValue.cpp
@@ -50,12 +50,8 @@ void Measurements::maxUpdate(AgValueType type, int max) {
 }
 
 bool Measurements::updateValue(AgValueType type, int val, int ch) {
-  // Validate channel
-  if (ch != 1 || ch != 2) {
-    Serial.printf(" Channel %d is undefined. Only channel 1 or 2 is the optional value!", ch);
-    // TODO: Perhaps just do assert
-    return false;
-  }
+  // Sanity check to validate channel, assert if invalid
+  validateChannel(ch);
 
   // Follow array indexing just for get address of the value type
   ch = ch - 1;
@@ -150,12 +146,8 @@ bool Measurements::updateValue(AgValueType type, int val, int ch) {
 }
 
 bool Measurements::updateValue(AgValueType type, float val, int ch) {
-  // Validate channel
-  if (ch != 1 || ch != 2) {
-    Serial.printf(" Channel %d is undefined. Only channel 1 or 2 is the optional value!", ch);
-    // TODO: Perhaps just do assert
-    return false;
-  }
+  // Sanity check to validate channel, assert if invalid
+  validateChannel(ch);
 
   // Follow array indexing just for get address of the value type
   ch = ch - 1;
@@ -222,6 +214,9 @@ bool Measurements::updateValue(AgValueType type, float val, int ch) {
 }
 
 int Measurements::getValue(AgValueType type, bool average, int ch) {
+  // Sanity check to validate channel, assert if invalid
+  validateChannel(ch);
+
   // Follow array indexing just for get address of the value type
   ch = ch - 1;
 
@@ -275,6 +270,9 @@ int Measurements::getValue(AgValueType type, bool average, int ch) {
 }
 
 float Measurements::getValueFloat(AgValueType type, bool average, int ch) {
+  // Sanity check to validate channel, assert if invalid
+  validateChannel(ch);
+
   // Define data point source
   FloatValue *temporary = nullptr;
   switch (type) {

--- a/src/AgValue.cpp
+++ b/src/AgValue.cpp
@@ -728,3 +728,11 @@ String Measurements::agValueTypeStr(AgValueType type) {
 
   return str;
 }
+
+void Measurements::validateChannel(int ch) {
+  if (ch != 1 && ch != 2) {
+    Serial.printf("ERROR! Channel %d is undefined. Only channel 1 or 2 is the optional value!", ch);
+    delay(1000);
+    assert(0);
+  }
+}

--- a/src/AgValue.cpp
+++ b/src/AgValue.cpp
@@ -546,7 +546,6 @@ JSONVar Measurements::buildPMS(AirGradient &ag, int ch, bool allCh, bool withTem
             utils::isValidHumidity(_humidity[ch].update.avg)) {
           // Note: the pms5003t object is not matter either for channel 1 or 2, compensate points to
           // the same base function
-          // TODO: Need to use compensated humidity?
           float pm25 = ag.pms5003t_1.compensate(_pm_25[ch].update.avg, _humidity[ch].update.avg);
           if (utils::isValidPm(pm25)) {
             pms["pm02Compensated"] = ag.round2(pm25);
@@ -719,7 +718,7 @@ JSONVar Measurements::buildPMS(AirGradient &ag, int ch, bool allCh, bool withTem
 
       /// Get average or one of the channel compensated value if only one channel is valid
       if (utils::isValidPm(pm25_comp1) && utils::isValidPm(pm25_comp2)) {
-        pms["pm02Compensated"] = ag.round2((pm25_comp1 / pm25_comp2) / 2.0f);
+        pms["pm02Compensated"] = ag.round2((pm25_comp1 + pm25_comp2) / 2.0f);
       } else if (utils::isValidPm(pm25_comp1)) {
         pms["pm02Compensated"] = ag.round2(pm25_comp1);
       } else if (utils::isValidPm(pm25_comp2)) {

--- a/src/AgValue.cpp
+++ b/src/AgValue.cpp
@@ -132,7 +132,9 @@ bool Measurements::update(MeasurementType type, int val, int ch) {
 
   // Calculate average based on how many elements on the list
   temporary->update.avg = temporary->sumValues / (float)temporary->listValues.size();
-  Serial.printf("%s{%d}: %.2f\n", measurementTypeStr(type), ch, temporary->update.avg);
+  if (_debug) {
+    Serial.printf("%s{%d}: %.2f\n", measurementTypeStr(type), ch, temporary->update.avg);
+  }
 
   return true;
 }
@@ -193,7 +195,9 @@ bool Measurements::update(MeasurementType type, float val, int ch) {
 
   // Calculate average based on how many elements on the list
   temporary->update.avg = temporary->sumValues / (float)temporary->listValues.size();
-  Serial.printf("%s{%d}: %.2f\n", measurementTypeStr(type), ch, temporary->update.avg);
+  if (_debug) {
+    Serial.printf("%s{%d}: %.2f\n", measurementTypeStr(type), ch, temporary->update.avg);
+  }
 
   return true;
 }
@@ -398,7 +402,7 @@ String Measurements::toString(bool localServer, AgFirmwareMode fwMode, int rssi,
   }
 
   String result = JSON.stringify(root);
-  Serial.printf("\n----\n %s \n-----\n", result.c_str());
+  Serial.printf("\n---- PAYLOAD\n %s \n-----\n", result.c_str());
   return result;
 }
 
@@ -725,3 +729,5 @@ JSONVar Measurements::buildPMS(AirGradient &ag, int ch, bool allCh, bool withTem
 
   return pms;
 }
+
+void Measurements::setDebug(bool debug) { _debug = debug; }

--- a/src/AgValue.cpp
+++ b/src/AgValue.cpp
@@ -193,7 +193,7 @@ bool Measurements::updateValue(AgValueType type, float val, int ch) {
     // TODO: Need to check if SUCCESS == 0
     // Calculate the average
     temporary->avg = temporary->sumValues / temporary->update.success;
-    Serial.printf("%s{%d} count reached! Average value %0.2f\n", agValueTypeStr(type),
+    Serial.printf("%s{%d} count reached! Average value %0.2f\n", agValueTypeStr(type), ch,
                   temporary->avg);
 
     // This is just for notifying

--- a/src/AgValue.cpp
+++ b/src/AgValue.cpp
@@ -5,79 +5,7 @@
 
 #define json_prop_pmFirmware     "firmware"
 
-/**
- * @brief Get PMS5003 firmware version string
- * 
- * @param fwCode 
- * @return String
- */
-String Measurements::pms5003FirmwareVersion(int fwCode) {
-  return pms5003FirmwareVersionBase("PMS5003x", fwCode);
-}
-
-/**
- * @brief Get PMS5003T firmware version string
- * 
- * @param fwCode 
- * @return String
- */
-String Measurements::pms5003TFirmwareVersion(int fwCode) {
-  return pms5003FirmwareVersionBase("PMS5003x", fwCode);
-}
-
-/**
- * @brief Get firmware version string
- * 
- * @param prefix Prefix firmware string
- * @param fwCode Version code
- * @return string 
- */
-String Measurements::pms5003FirmwareVersionBase(String prefix, int fwCode) {
-  return prefix + String("-") + String(fwCode);
-}
-
-String Measurements::agValueTypeStr(AgValueType type) {
-  String str;
-  switch (type) {
-  case AgValueType::Temperature:
-    str = "Temperature";
-    break;
-  case AgValueType::Humidity:
-    str = "Humidity";
-    break;
-  case AgValueType::CO2:
-    str = "CO2";
-    break;
-  case AgValueType::TVOC:
-    str = "TVOC";
-    break;
-  case AgValueType::TVOCRaw:
-    str = "TVOCRaw";
-    break;
-  case AgValueType::NOx:
-    str = "NOx";
-    break;
-  case AgValueType::NOxRaw:
-    str = "NOxRaw";
-    break;
-  case AgValueType::PM25:
-    str = "PM25";
-    break;
-  case AgValueType::PM01:
-    str = "PM01";
-    break;
-  case AgValueType::PM10:
-    str = "PM10";
-    break;
-  case AgValueType::PM03:
-    str = "PM03";
-    break;
-  default:
-    break;
-  };
-
-  return str;
-}
+void Measurements::init() {}
 
 bool Measurements::updateValue(AgValueType type, int val) {
   // Define data point source
@@ -593,4 +521,59 @@ String Measurements::toString(bool localServer, AgFirmwareMode fwMode, int rssi,
   }
 
   return JSON.stringify(root);
+}
+
+String Measurements::pms5003FirmwareVersion(int fwCode) {
+  return pms5003FirmwareVersionBase("PMS5003x", fwCode);
+}
+
+String Measurements::pms5003TFirmwareVersion(int fwCode) {
+  return pms5003FirmwareVersionBase("PMS5003x", fwCode);
+}
+
+String Measurements::pms5003FirmwareVersionBase(String prefix, int fwCode) {
+  return prefix + String("-") + String(fwCode);
+}
+
+String Measurements::agValueTypeStr(AgValueType type) {
+  String str;
+  switch (type) {
+  case AgValueType::Temperature:
+    str = "Temperature";
+    break;
+  case AgValueType::Humidity:
+    str = "Humidity";
+    break;
+  case AgValueType::CO2:
+    str = "CO2";
+    break;
+  case AgValueType::TVOC:
+    str = "TVOC";
+    break;
+  case AgValueType::TVOCRaw:
+    str = "TVOCRaw";
+    break;
+  case AgValueType::NOx:
+    str = "NOx";
+    break;
+  case AgValueType::NOxRaw:
+    str = "NOxRaw";
+    break;
+  case AgValueType::PM25:
+    str = "PM25";
+    break;
+  case AgValueType::PM01:
+    str = "PM01";
+    break;
+  case AgValueType::PM10:
+    str = "PM10";
+    break;
+  case AgValueType::PM03:
+    str = "PM03";
+    break;
+  default:
+    break;
+  };
+
+  return str;
 }

--- a/src/AgValue.cpp
+++ b/src/AgValue.cpp
@@ -300,6 +300,8 @@ float Measurements::getValueFloat(AgValueType type, bool average, int ch) {
   return temporary->lastValue;
 }
 
+String Measurements::toString(bool localServer, AgFirmwareMode fwMode, int rssi, void *_ag,
+                              void *_config) {
   AirGradient *ag = (AirGradient *)_ag;
   Configuration *config = (Configuration *)_config;
 

--- a/src/AgValue.cpp
+++ b/src/AgValue.cpp
@@ -5,7 +5,43 @@
 
 #define json_prop_pmFirmware     "firmware"
 
-void Measurements::init() {}
+void Measurements::maxUpdate(AgValueType type, int max) {
+  switch (type) {
+  case AgValueType::Temperature:
+    _temperature.update.max = max;
+    break;
+  case AgValueType::Humidity:
+    _humidity.update.max = max;
+    break;
+  case AgValueType::CO2:
+    _co2.update.max = max;
+    break;
+  case AgValueType::TVOC:
+    _tvoc.update.max = max;
+    break;
+  case AgValueType::TVOCRaw:
+    _tvoc_raw.update.max = max;
+    break;
+  case AgValueType::NOx:
+    _nox.update.max = max;
+    break;
+  case AgValueType::NOxRaw:
+    _nox_raw.update.max = max;
+    break;
+  case AgValueType::PM25:
+    _pm_25.update.max = max;
+    break;
+  case AgValueType::PM01:
+    _pm_01.update.max = max;
+    break;
+  case AgValueType::PM10:
+    _pm_10.update.max = max;
+    break;
+  case AgValueType::PM03_PC:
+    _pm_03_pc.update.max = max;
+    break;
+  };
+}
 
 bool Measurements::updateValue(AgValueType type, int val) {
   // Define data point source
@@ -44,7 +80,7 @@ bool Measurements::updateValue(AgValueType type, int val) {
     temporary = &_pm_10;
     invalidValue = utils::getInvalidPmValue();
     break;
-  case AgValueType::PM03:
+  case AgValueType::PM03_PC:
     temporary = &_pm_03_pc;
     invalidValue = utils::getInvalidPmValue();
     break;
@@ -568,7 +604,7 @@ String Measurements::agValueTypeStr(AgValueType type) {
   case AgValueType::PM10:
     str = "PM10";
     break;
-  case AgValueType::PM03:
+  case AgValueType::PM03_PC:
     str = "PM03";
     break;
   default:

--- a/src/AgValue.cpp
+++ b/src/AgValue.cpp
@@ -221,8 +221,87 @@ bool Measurements::updateValue(AgValueType type, float val, int ch) {
   return false;
 }
 
-String Measurements::toString(bool localServer, AgFirmwareMode fwMode, int rssi,
-                              void *_ag, void *_config) {
+int Measurements::getValue(AgValueType type, bool average, int ch) {
+  // Follow array indexing just for get address of the value type
+  ch = ch - 1;
+
+  // Define data point source
+  IntegerValue *temporary = nullptr;
+  float invalidValue = 0;
+  switch (type) {
+  case AgValueType::CO2:
+    temporary = &_co2;
+    break;
+  case AgValueType::TVOC:
+    temporary = &_tvoc;
+    break;
+  case AgValueType::TVOCRaw:
+    temporary = &_tvoc_raw;
+    break;
+  case AgValueType::NOx:
+    temporary = &_nox;
+    break;
+  case AgValueType::NOxRaw:
+    temporary = &_nox_raw;
+    break;
+  case AgValueType::PM25:
+    temporary = &_pm_25[ch];
+    break;
+  case AgValueType::PM01:
+    temporary = &_pm_01[ch];
+    break;
+  case AgValueType::PM10:
+    temporary = &_pm_10[ch];
+    break;
+  case AgValueType::PM03_PC:
+    temporary = &_pm_03_pc[ch];
+    break;
+  default:
+    break;
+  };
+
+  // Sanity check if agvaluetype is defined for integer data type or not
+  if (temporary == nullptr) {
+    Serial.printf("%s is not defined for integer data type\n", agValueTypeStr(type));
+    // TODO: Just assert?
+    return false;
+  }
+
+  if (average) {
+    return temporary->avg;
+  }
+
+  return temporary->lastValue;
+}
+
+float Measurements::getValueFloat(AgValueType type, bool average, int ch) {
+  // Define data point source
+  FloatValue *temporary = nullptr;
+  switch (type) {
+  case AgValueType::Temperature:
+    temporary = &_temperature[ch];
+    break;
+  case AgValueType::Humidity:
+    temporary = &_humidity[ch];
+    break;
+  default:
+    break;
+  }
+
+  // Sanity check if agvaluetype is defined for float data type or not
+  if (temporary == nullptr) {
+    Serial.printf("%s is not defined for float data type\n", agValueTypeStr(type));
+    // TODO: Just assert?
+    return false;
+  }
+
+  if (average) {
+    return temporary->avg;
+  }
+
+  return temporary->lastValue;
+}
+
   AirGradient *ag = (AirGradient *)_ag;
   Configuration *config = (Configuration *)_config;
 

--- a/src/AgValue.cpp
+++ b/src/AgValue.cpp
@@ -131,8 +131,8 @@ bool Measurements::update(MeasurementType type, int val, int ch) {
   }
 
   // Calculate average based on how many elements on the list
-  temporary->avg = temporary->sumValues / (float)temporary->listValues.size();
-  Serial.printf("%s{%d}: %.2f\n", measurementTypeStr(type), ch, temporary->avg);
+  temporary->update.avg = temporary->sumValues / (float)temporary->listValues.size();
+  Serial.printf("%s{%d}: %.2f\n", measurementTypeStr(type), ch, temporary->update.avg);
 
   return true;
 }
@@ -192,8 +192,8 @@ bool Measurements::update(MeasurementType type, float val, int ch) {
   }
 
   // Calculate average based on how many elements on the list
-  temporary->avg = temporary->sumValues / (float)temporary->listValues.size();
-  Serial.printf("%s{%d}: %.2f\n", measurementTypeStr(type), ch, temporary->avg);
+  temporary->update.avg = temporary->sumValues / (float)temporary->listValues.size();
+  Serial.printf("%s{%d}: %.2f\n", measurementTypeStr(type), ch, temporary->update.avg);
 
   return true;
 }
@@ -254,7 +254,7 @@ int Measurements::get(MeasurementType type, bool average, int ch) {
 
   if (average) {
     // TODO: This now is average value, need to update this
-    return temporary->avg;
+    return temporary->update.avg;
   }
 
   return temporary->listValues.back();
@@ -293,7 +293,7 @@ float Measurements::getFloat(MeasurementType type, bool average, int ch) {
   }
 
   if (average) {
-    return temporary->avg;
+    return temporary->update.avg;
   }
 
   return temporary->listValues.back();
@@ -373,23 +373,23 @@ String Measurements::toString(bool localServer, AgFirmwareMode fwMode, int rssi,
   }
 
   // CO2
-  if (config.hasSensorS8 && utils::isValidCO2(_co2.avg)) {
-    root["rco2"] = ag.round2(_co2.avg);
+  if (config.hasSensorS8 && utils::isValidCO2(_co2.update.avg)) {
+    root["rco2"] = ag.round2(_co2.update.avg);
   }
 
   /// TVOx and NOx
   if (config.hasSensorSGP) {
-    if (utils::isValidVOC(_tvoc.avg)) {
-      root["tvocIndex"] = ag.round2(_tvoc.avg);
+    if (utils::isValidVOC(_tvoc.update.avg)) {
+      root["tvocIndex"] = ag.round2(_tvoc.update.avg);
     }
-    if (utils::isValidVOC(_tvoc_raw.avg)) {
-      root["tvocRaw"] = ag.round2(_tvoc_raw.avg);
+    if (utils::isValidVOC(_tvoc_raw.update.avg)) {
+      root["tvocRaw"] = ag.round2(_tvoc_raw.update.avg);
     }
-    if (utils::isValidNOx(_nox.avg)) {
-      root["noxIndex"] = ag.round2(_nox.avg);
+    if (utils::isValidNOx(_nox.update.avg)) {
+      root["noxIndex"] = ag.round2(_nox.update.avg);
     }
-    if (utils::isValidNOx(_nox_raw.avg)) {
-      root["noxRaw"] = ag.round2(_nox_raw.avg);
+    if (utils::isValidNOx(_nox_raw.update.avg)) {
+      root["noxRaw"] = ag.round2(_nox_raw.update.avg);
     }
   }
 
@@ -467,25 +467,25 @@ JSONVar Measurements::buildIndoor(bool localServer, AirGradient &ag, Configurati
 
   if (config.hasSensorSHT) {
     // Add temperature
-    if (utils::isValidTemperature(_temperature[0].avg)) {
-      indoor["atmp"] = ag.round2(_temperature[0].avg);
+    if (utils::isValidTemperature(_temperature[0].update.avg)) {
+      indoor["atmp"] = ag.round2(_temperature[0].update.avg);
       if (localServer) {
-        indoor["atmpCompensated"] = ag.round2(_temperature[0].avg);
+        indoor["atmpCompensated"] = ag.round2(_temperature[0].update.avg);
       }
     }
     // Add humidity
-    if (utils::isValidHumidity(_humidity[0].avg)) {
-      indoor["rhum"] = ag.round2(_humidity[0].avg);
+    if (utils::isValidHumidity(_humidity[0].update.avg)) {
+      indoor["rhum"] = ag.round2(_humidity[0].update.avg);
       if (localServer) {
-        indoor["rhumCompensated"] = ag.round2(_humidity[0].avg);
+        indoor["rhumCompensated"] = ag.round2(_humidity[0].update.avg);
       }
     }
   }
 
   // Add pm25 compensated value only if PM2.5 and humidity value is valid
-  if (config.hasSensorPMS1 && utils::isValidPm(_pm_25[0].avg)) {
-    if (config.hasSensorSHT && utils::isValidHumidity(_humidity[0].avg)) {
-      int pm25 = ag.pms5003.compensate(_pm_25[0].avg, _humidity[0].avg);
+  if (config.hasSensorPMS1 && utils::isValidPm(_pm_25[0].update.avg)) {
+    if (config.hasSensorSHT && utils::isValidHumidity(_humidity[0].update.avg)) {
+      int pm25 = ag.pms5003.compensate(_pm_25[0].update.avg, _humidity[0].update.avg);
       if (utils::isValidPm(pm25)) {
         indoor["pm02Compensated"] = pm25;
       }
@@ -507,38 +507,38 @@ JSONVar Measurements::buildPMS(AirGradient &ag, int ch, bool allCh, bool withTem
     // Follow array indexing just for get address of the value type
     ch = ch - 1;
 
-    if (utils::isValidPm(_pm_01[ch].avg)) {
-      pms["pm01"] = ag.round2(_pm_01[ch].avg);
+    if (utils::isValidPm(_pm_01[ch].update.avg)) {
+      pms["pm01"] = ag.round2(_pm_01[ch].update.avg);
     }
-    if (utils::isValidPm(_pm_25[ch].avg)) {
-      pms["pm02"] = ag.round2(_pm_25[ch].avg);
+    if (utils::isValidPm(_pm_25[ch].update.avg)) {
+      pms["pm02"] = ag.round2(_pm_25[ch].update.avg);
     }
-    if (utils::isValidPm(_pm_10[ch].avg)) {
-      pms["pm10"] = ag.round2(_pm_10[ch].avg);
+    if (utils::isValidPm(_pm_10[ch].update.avg)) {
+      pms["pm10"] = ag.round2(_pm_10[ch].update.avg);
     }
-    if (utils::isValidPm03Count(_pm_03_pc[ch].avg)) {
-      pms["pm003Count"] = ag.round2(_pm_03_pc[ch].avg);
+    if (utils::isValidPm03Count(_pm_03_pc[ch].update.avg)) {
+      pms["pm003Count"] = ag.round2(_pm_03_pc[ch].update.avg);
     }
 
     if (withTempHum) {
       float _vc;
       // Set temperature if valid
-      if (utils::isValidTemperature(_temperature[ch].avg)) {
-        pms["atmp"] = ag.round2(_temperature[ch].avg);
+      if (utils::isValidTemperature(_temperature[ch].update.avg)) {
+        pms["atmp"] = ag.round2(_temperature[ch].update.avg);
         // Compensate temperature when flag is set
         if (compensate) {
-          _vc = ag.pms5003t_1.compensateTemp(_temperature[ch].avg);
+          _vc = ag.pms5003t_1.compensateTemp(_temperature[ch].update.avg);
           if (utils::isValidTemperature(_vc)) {
             pms["atmpCompensated"] = ag.round2(_vc);
           }
         }
       }
       // Set humidity if valid
-      if (utils::isValidHumidity(_humidity[ch].avg)) {
-        pms["rhum"] = ag.round2(_humidity[ch].avg);
+      if (utils::isValidHumidity(_humidity[ch].update.avg)) {
+        pms["rhum"] = ag.round2(_humidity[ch].update.avg);
         // Compensate relative humidity when flag is set
         if (compensate) {
-          _vc = ag.pms5003t_1.compensateHum(_humidity[ch].avg);
+          _vc = ag.pms5003t_1.compensateHum(_humidity[ch].update.avg);
           if (utils::isValidTemperature(_vc)) {
             pms["rhumCompensated"] = ag.round2(_vc);
           }
@@ -547,10 +547,11 @@ JSONVar Measurements::buildPMS(AirGradient &ag, int ch, bool allCh, bool withTem
 
       // Add pm25 compensated value only if PM2.5 and humidity value is valid
       if (compensate) {
-        if (utils::isValidPm(_pm_25[ch].avg) && utils::isValidHumidity(_humidity[ch].avg)) {
+        if (utils::isValidPm(_pm_25[ch].update.avg) &&
+            utils::isValidHumidity(_humidity[ch].update.avg)) {
           // Note: the pms5003t object is not matter either for channel 1 or 2, compensate points to
           // the same base function
-          int pm25 = ag.pms5003t_1.compensate(_pm_25[ch].avg, _humidity[ch].avg);
+          int pm25 = ag.pms5003t_1.compensate(_pm_25[ch].update.avg, _humidity[ch].update.avg);
           if (utils::isValidPm(pm25)) {
             pms["pm02Compensated"] = pm25;
           }
@@ -564,139 +565,141 @@ JSONVar Measurements::buildPMS(AirGradient &ag, int ch, bool allCh, bool withTem
 
   // Handle both channel with average, if one of the channel not valid, use another one
   /// PM01
-  if (utils::isValidPm(_pm_01[0].avg) && utils::isValidPm(_pm_01[1].avg)) {
-    float avg = (_pm_01[0].avg + _pm_01[1].avg) / 2.0f;
+  if (utils::isValidPm(_pm_01[0].update.avg) && utils::isValidPm(_pm_01[1].update.avg)) {
+    float avg = (_pm_01[0].update.avg + _pm_01[1].update.avg) / 2.0f;
     pms["pm01"] = ag.round2(avg);
-    pms["channels"]["1"]["pm01"] = ag.round2(_pm_01[0].avg);
-    pms["channels"]["2"]["pm01"] = ag.round2(_pm_01[1].avg);
-  } else if (utils::isValidPm(_pm_01[0].avg)) {
-    pms["pm01"] = ag.round2(_pm_01[0].avg);
-    pms["channels"]["1"]["pm01"] = ag.round2(_pm_01[0].avg);
-  } else if (utils::isValidPm(_pm_01[1].avg)) {
-    pms["pm01"] = ag.round2(_pm_01[1].avg);
-    pms["channels"]["2"]["pm01"] = ag.round2(_pm_01[1].avg);
+    pms["channels"]["1"]["pm01"] = ag.round2(_pm_01[0].update.avg);
+    pms["channels"]["2"]["pm01"] = ag.round2(_pm_01[1].update.avg);
+  } else if (utils::isValidPm(_pm_01[0].update.avg)) {
+    pms["pm01"] = ag.round2(_pm_01[0].update.avg);
+    pms["channels"]["1"]["pm01"] = ag.round2(_pm_01[0].update.avg);
+  } else if (utils::isValidPm(_pm_01[1].update.avg)) {
+    pms["pm01"] = ag.round2(_pm_01[1].update.avg);
+    pms["channels"]["2"]["pm01"] = ag.round2(_pm_01[1].update.avg);
   }
 
   /// PM2.5
-  if (utils::isValidPm(_pm_25[0].avg) && utils::isValidPm(_pm_25[1].avg)) {
-    float avg = (_pm_25[0].avg + _pm_25[1].avg) / 2.0f;
+  if (utils::isValidPm(_pm_25[0].update.avg) && utils::isValidPm(_pm_25[1].update.avg)) {
+    float avg = (_pm_25[0].update.avg + _pm_25[1].update.avg) / 2.0f;
     pms["pm02"] = ag.round2(avg);
-    pms["channels"]["1"]["pm02"] = ag.round2(_pm_25[0].avg);
-    pms["channels"]["2"]["pm02"] = ag.round2(_pm_25[1].avg);
-  } else if (utils::isValidPm(_pm_25[0].avg)) {
-    pms["pm02"] = ag.round2(_pm_25[0].avg);
-    pms["channels"]["1"]["pm02"] = ag.round2(_pm_25[0].avg);
-  } else if (utils::isValidPm(_pm_25[1].avg)) {
-    pms["pm02"] = ag.round2(_pm_25[1].avg);
-    pms["channels"]["2"]["pm02"] = ag.round2(_pm_25[1].avg);
+    pms["channels"]["1"]["pm02"] = ag.round2(_pm_25[0].update.avg);
+    pms["channels"]["2"]["pm02"] = ag.round2(_pm_25[1].update.avg);
+  } else if (utils::isValidPm(_pm_25[0].update.avg)) {
+    pms["pm02"] = ag.round2(_pm_25[0].update.avg);
+    pms["channels"]["1"]["pm02"] = ag.round2(_pm_25[0].update.avg);
+  } else if (utils::isValidPm(_pm_25[1].update.avg)) {
+    pms["pm02"] = ag.round2(_pm_25[1].update.avg);
+    pms["channels"]["2"]["pm02"] = ag.round2(_pm_25[1].update.avg);
   }
 
   /// PM10
-  if (utils::isValidPm(_pm_10[0].avg) && utils::isValidPm(_pm_10[1].avg)) {
-    float avg = (_pm_10[0].avg + _pm_10[1].avg) / 2.0f;
+  if (utils::isValidPm(_pm_10[0].update.avg) && utils::isValidPm(_pm_10[1].update.avg)) {
+    float avg = (_pm_10[0].update.avg + _pm_10[1].update.avg) / 2.0f;
     pms["pm10"] = ag.round2(avg);
-    pms["channels"]["1"]["pm10"] = ag.round2(_pm_10[0].avg);
-    pms["channels"]["2"]["pm10"] = ag.round2(_pm_10[1].avg);
-  } else if (utils::isValidPm(_pm_10[0].avg)) {
-    pms["pm10"] = ag.round2(_pm_10[0].avg);
-    pms["channels"]["1"]["pm10"] = ag.round2(_pm_10[0].avg);
-  } else if (utils::isValidPm(_pm_10[1].avg)) {
-    pms["pm10"] = ag.round2(_pm_10[1].avg);
-    pms["channels"]["2"]["pm10"] = ag.round2(_pm_10[1].avg);
+    pms["channels"]["1"]["pm10"] = ag.round2(_pm_10[0].update.avg);
+    pms["channels"]["2"]["pm10"] = ag.round2(_pm_10[1].update.avg);
+  } else if (utils::isValidPm(_pm_10[0].update.avg)) {
+    pms["pm10"] = ag.round2(_pm_10[0].update.avg);
+    pms["channels"]["1"]["pm10"] = ag.round2(_pm_10[0].update.avg);
+  } else if (utils::isValidPm(_pm_10[1].update.avg)) {
+    pms["pm10"] = ag.round2(_pm_10[1].update.avg);
+    pms["channels"]["2"]["pm10"] = ag.round2(_pm_10[1].update.avg);
   }
 
   /// PM03 particle count
-  if (utils::isValidPm03Count(_pm_03_pc[0].avg) && utils::isValidPm03Count(_pm_03_pc[1].avg)) {
-    float avg = (_pm_03_pc[0].avg + _pm_03_pc[1].avg) / 2.0f;
+  if (utils::isValidPm03Count(_pm_03_pc[0].update.avg) &&
+      utils::isValidPm03Count(_pm_03_pc[1].update.avg)) {
+    float avg = (_pm_03_pc[0].update.avg + _pm_03_pc[1].update.avg) / 2.0f;
     pms["pm003Count"] = ag.round2(avg);
-    pms["channels"]["1"]["pm003Count"] = ag.round2(_pm_03_pc[0].avg);
-    pms["channels"]["2"]["pm003Count"] = ag.round2(_pm_03_pc[1].avg);
-  } else if (utils::isValidPm(_pm_03_pc[0].avg)) {
-    pms["pm003Count"] = ag.round2(_pm_03_pc[0].avg);
-    pms["channels"]["1"]["pm003Count"] = ag.round2(_pm_03_pc[0].avg);
-  } else if (utils::isValidPm(_pm_03_pc[1].avg)) {
-    pms["pm003Count"] = ag.round2(_pm_03_pc[1].avg);
-    pms["channels"]["2"]["pm003Count"] = ag.round2(_pm_03_pc[1].avg);
+    pms["channels"]["1"]["pm003Count"] = ag.round2(_pm_03_pc[0].update.avg);
+    pms["channels"]["2"]["pm003Count"] = ag.round2(_pm_03_pc[1].update.avg);
+  } else if (utils::isValidPm(_pm_03_pc[0].update.avg)) {
+    pms["pm003Count"] = ag.round2(_pm_03_pc[0].update.avg);
+    pms["channels"]["1"]["pm003Count"] = ag.round2(_pm_03_pc[0].update.avg);
+  } else if (utils::isValidPm(_pm_03_pc[1].update.avg)) {
+    pms["pm003Count"] = ag.round2(_pm_03_pc[1].update.avg);
+    pms["channels"]["2"]["pm003Count"] = ag.round2(_pm_03_pc[1].update.avg);
   }
 
   if (withTempHum) {
     /// Temperature
-    if (utils::isValidTemperature(_temperature[0].avg) &&
-        utils::isValidTemperature(_temperature[1].avg)) {
+    if (utils::isValidTemperature(_temperature[0].update.avg) &&
+        utils::isValidTemperature(_temperature[1].update.avg)) {
 
-      float temperature = (_temperature[0].avg + _temperature[1].avg) / 2.0f;
+      float temperature = (_temperature[0].update.avg + _temperature[1].update.avg) / 2.0f;
       pms["atmp"] = ag.round2(temperature);
-      pms["channels"]["1"]["atmp"] = ag.round2(_temperature[0].avg);
-      pms["channels"]["2"]["atmp"] = ag.round2(_temperature[1].avg);
+      pms["channels"]["1"]["atmp"] = ag.round2(_temperature[0].update.avg);
+      pms["channels"]["2"]["atmp"] = ag.round2(_temperature[1].update.avg);
 
       if (compensate) {
         // Compensate both temperature channel
         float temp = ag.pms5003t_1.compensateTemp(temperature);
-        float temp1 = ag.pms5003t_1.compensateTemp(_temperature[0].avg);
-        float temp2 = ag.pms5003t_2.compensateTemp(_temperature[1].avg);
+        float temp1 = ag.pms5003t_1.compensateTemp(_temperature[0].update.avg);
+        float temp2 = ag.pms5003t_2.compensateTemp(_temperature[1].update.avg);
         pms["atmpCompensated"] = ag.round2(temp);
         pms["channels"]["1"]["atmpCompensated"] = ag.round2(temp1);
         pms["channels"]["2"]["atmpCompensated"] = ag.round2(temp2);
       }
 
-    } else if (utils::isValidTemperature(_temperature[0].avg)) {
-      pms["atmp"] = ag.round2(_temperature[0].avg);
-      pms["channels"]["1"]["atmp"] = ag.round2(_temperature[0].avg);
+    } else if (utils::isValidTemperature(_temperature[0].update.avg)) {
+      pms["atmp"] = ag.round2(_temperature[0].update.avg);
+      pms["channels"]["1"]["atmp"] = ag.round2(_temperature[0].update.avg);
 
       if (compensate) {
         // Compensate channel 1
-        float temp1 = ag.pms5003t_1.compensateTemp(_temperature[0].avg);
+        float temp1 = ag.pms5003t_1.compensateTemp(_temperature[0].update.avg);
         pms["atmpCompensated"] = ag.round2(temp1);
         pms["channels"]["1"]["atmpCompensated"] = ag.round2(temp1);
       }
 
-    } else if (utils::isValidTemperature(_temperature[1].avg)) {
-      pms["atmp"] = ag.round2(_temperature[1].avg);
-      pms["channels"]["2"]["atmp"] = ag.round2(_temperature[1].avg);
+    } else if (utils::isValidTemperature(_temperature[1].update.avg)) {
+      pms["atmp"] = ag.round2(_temperature[1].update.avg);
+      pms["channels"]["2"]["atmp"] = ag.round2(_temperature[1].update.avg);
 
       if (compensate) {
         // Compensate channel 2
-        float temp2 = ag.pms5003t_2.compensateTemp(_temperature[1].avg);
+        float temp2 = ag.pms5003t_2.compensateTemp(_temperature[1].update.avg);
         pms["atmpCompensated"] = ag.round2(temp2);
         pms["channels"]["2"]["atmpCompensated"] = ag.round2(temp2);
       }
     }
 
     /// Relative humidity
-    if (utils::isValidHumidity(_humidity[0].avg) && utils::isValidHumidity(_humidity[1].avg)) {
-      float humidity = (_humidity[0].avg + _humidity[1].avg) / 2.0f;
+    if (utils::isValidHumidity(_humidity[0].update.avg) &&
+        utils::isValidHumidity(_humidity[1].update.avg)) {
+      float humidity = (_humidity[0].update.avg + _humidity[1].update.avg) / 2.0f;
       pms["rhum"] = ag.round2(humidity);
-      pms["channels"]["1"]["rhum"] = ag.round2(_humidity[0].avg);
-      pms["channels"]["2"]["rhum"] = ag.round2(_humidity[1].avg);
+      pms["channels"]["1"]["rhum"] = ag.round2(_humidity[0].update.avg);
+      pms["channels"]["2"]["rhum"] = ag.round2(_humidity[1].update.avg);
 
       if (compensate) {
         // Compensate both humidity channel
         float hum = ag.pms5003t_1.compensateHum(humidity);
-        float hum1 = ag.pms5003t_1.compensateHum(_humidity[0].avg);
-        float hum2 = ag.pms5003t_2.compensateHum(_humidity[1].avg);
+        float hum1 = ag.pms5003t_1.compensateHum(_humidity[0].update.avg);
+        float hum2 = ag.pms5003t_2.compensateHum(_humidity[1].update.avg);
         pms["rhumCompensated"] = ag.round2(hum);
         pms["channels"]["1"]["rhumCompensated"] = ag.round2(hum1);
         pms["channels"]["2"]["rhumCompensated"] = ag.round2(hum2);
       }
 
-    } else if (utils::isValidHumidity(_humidity[0].avg)) {
-      pms["rhum"] = ag.round2(_humidity[0].avg);
-      pms["channels"]["1"]["rhum"] = ag.round2(_humidity[0].avg);
+    } else if (utils::isValidHumidity(_humidity[0].update.avg)) {
+      pms["rhum"] = ag.round2(_humidity[0].update.avg);
+      pms["channels"]["1"]["rhum"] = ag.round2(_humidity[0].update.avg);
 
       if (compensate) {
         // Compensate humidity channel 1
-        float hum1 = ag.pms5003t_1.compensateHum(_humidity[0].avg);
+        float hum1 = ag.pms5003t_1.compensateHum(_humidity[0].update.avg);
         pms["rhumCompensated"] = ag.round2(hum1);
         pms["channels"]["1"]["rhumCompensated"] = ag.round2(hum1);
       }
 
-    } else if (utils::isValidHumidity(_humidity[1].avg)) {
-      pms["rhum"] = ag.round2(_humidity[1].avg);
-      pms["channels"]["2"]["rhum"] = ag.round2(_humidity[1].avg);
+    } else if (utils::isValidHumidity(_humidity[1].update.avg)) {
+      pms["rhum"] = ag.round2(_humidity[1].update.avg);
+      pms["channels"]["2"]["rhum"] = ag.round2(_humidity[1].update.avg);
 
       if (compensate) {
         // Compensate humidity channel 2
-        float hum2 = ag.pms5003t_2.compensateHum(_humidity[1].avg);
+        float hum2 = ag.pms5003t_2.compensateHum(_humidity[1].update.avg);
         pms["rhumCompensated"] = ag.round2(hum2);
         pms["channels"]["2"]["rhumCompensated"] = ag.round2(hum2);
       }
@@ -707,12 +710,14 @@ JSONVar Measurements::buildPMS(AirGradient &ag, int ch, bool allCh, bool withTem
       /// First get both channel compensated value
       int pm25_comp1 = utils::getInvalidPmValue();
       int pm25_comp2 = utils::getInvalidPmValue();
-      if (utils::isValidPm(_pm_25[0].avg) && utils::isValidHumidity(_humidity[0].avg)) {
-        pm25_comp1 = ag.pms5003t_1.compensate(_pm_25[0].avg, _humidity[0].avg);
+      if (utils::isValidPm(_pm_25[0].update.avg) &&
+          utils::isValidHumidity(_humidity[0].update.avg)) {
+        pm25_comp1 = ag.pms5003t_1.compensate(_pm_25[0].update.avg, _humidity[0].update.avg);
         pms["channels"]["1"]["pm02Compensated"] = pm25_comp1;
       }
-      if (utils::isValidPm(_pm_25[1].avg) && utils::isValidHumidity(_humidity[1].avg)) {
-        pm25_comp2 = ag.pms5003t_2.compensate(_pm_25[1].avg, _humidity[1].avg);
+      if (utils::isValidPm(_pm_25[1].update.avg) &&
+          utils::isValidHumidity(_humidity[1].update.avg)) {
+        pm25_comp2 = ag.pms5003t_2.compensate(_pm_25[1].update.avg, _humidity[1].update.avg);
         pms["channels"]["2"]["pm02Compensated"] = pm25_comp2;
       }
 

--- a/src/AgValue.cpp
+++ b/src/AgValue.cpp
@@ -480,9 +480,9 @@ JSONVar Measurements::buildIndoor(bool localServer, AirGradient &ag, Configurati
   // Add pm25 compensated value only if PM2.5 and humidity value is valid
   if (config.hasSensorPMS1 && utils::isValidPm(_pm_25[0].update.avg)) {
     if (config.hasSensorSHT && utils::isValidHumidity(_humidity[0].update.avg)) {
-      int pm25 = ag.pms5003.compensate(_pm_25[0].update.avg, _humidity[0].update.avg);
+      float pm25 = ag.pms5003.compensate(_pm_25[0].update.avg, _humidity[0].update.avg);
       if (utils::isValidPm(pm25)) {
-        indoor["pm02Compensated"] = pm25;
+        indoor["pm02Compensated"] = ag.round2(pm25);
       }
     }
   }
@@ -546,9 +546,10 @@ JSONVar Measurements::buildPMS(AirGradient &ag, int ch, bool allCh, bool withTem
             utils::isValidHumidity(_humidity[ch].update.avg)) {
           // Note: the pms5003t object is not matter either for channel 1 or 2, compensate points to
           // the same base function
-          int pm25 = ag.pms5003t_1.compensate(_pm_25[ch].update.avg, _humidity[ch].update.avg);
+          // TODO: Need to use compensated humidity?
+          float pm25 = ag.pms5003t_1.compensate(_pm_25[ch].update.avg, _humidity[ch].update.avg);
           if (utils::isValidPm(pm25)) {
-            pms["pm02Compensated"] = pm25;
+            pms["pm02Compensated"] = ag.round2(pm25);
           }
         }
       }
@@ -703,26 +704,26 @@ JSONVar Measurements::buildPMS(AirGradient &ag, int ch, bool allCh, bool withTem
     if (compensate) {
       // Add pm25 compensated value
       /// First get both channel compensated value
-      int pm25_comp1 = utils::getInvalidPmValue();
-      int pm25_comp2 = utils::getInvalidPmValue();
+      float pm25_comp1 = utils::getInvalidPmValue();
+      float pm25_comp2 = utils::getInvalidPmValue();
       if (utils::isValidPm(_pm_25[0].update.avg) &&
           utils::isValidHumidity(_humidity[0].update.avg)) {
         pm25_comp1 = ag.pms5003t_1.compensate(_pm_25[0].update.avg, _humidity[0].update.avg);
-        pms["channels"]["1"]["pm02Compensated"] = pm25_comp1;
+        pms["channels"]["1"]["pm02Compensated"] = ag.round2(pm25_comp1);
       }
       if (utils::isValidPm(_pm_25[1].update.avg) &&
           utils::isValidHumidity(_humidity[1].update.avg)) {
         pm25_comp2 = ag.pms5003t_2.compensate(_pm_25[1].update.avg, _humidity[1].update.avg);
-        pms["channels"]["2"]["pm02Compensated"] = pm25_comp2;
+        pms["channels"]["2"]["pm02Compensated"] = ag.round2(pm25_comp2);
       }
 
       /// Get average or one of the channel compensated value if only one channel is valid
       if (utils::isValidPm(pm25_comp1) && utils::isValidPm(pm25_comp2)) {
         pms["pm02Compensated"] = ag.round2((pm25_comp1 / pm25_comp2) / 2.0f);
       } else if (utils::isValidPm(pm25_comp1)) {
-        pms["pm02Compensated"] = pm25_comp1;
+        pms["pm02Compensated"] = ag.round2(pm25_comp1);
       } else if (utils::isValidPm(pm25_comp2)) {
-        pms["pm02Compensated"] = pm25_comp2;
+        pms["pm02Compensated"] = ag.round2(pm25_comp2);
       }
     }
   }

--- a/src/AgValue.cpp
+++ b/src/AgValue.cpp
@@ -57,7 +57,7 @@ bool Measurements::update(MeasurementType type, int val, int ch) {
 
   // Define data point source
   IntegerValue *temporary = nullptr;
-  float invalidValue = 0;
+  int invalidValue = 0;
   switch (type) {
   case CO2:
     temporary = &_co2;
@@ -225,7 +225,6 @@ int Measurements::get(MeasurementType type, int ch) {
 
   // Define data point source
   IntegerValue *temporary = nullptr;
-  float invalidValue = 0;
   switch (type) {
   case CO2:
     temporary = &_co2;

--- a/src/AgValue.cpp
+++ b/src/AgValue.cpp
@@ -198,7 +198,7 @@ bool Measurements::update(MeasurementType type, float val, int ch) {
   return true;
 }
 
-int Measurements::get(MeasurementType type, bool average, int ch) {
+int Measurements::get(MeasurementType type, int ch) {
   // Sanity check to validate channel, assert if invalid
   validateChannel(ch);
 
@@ -252,15 +252,10 @@ int Measurements::get(MeasurementType type, bool average, int ch) {
     return 0;
   }
 
-  if (average) {
-    // TODO: This now is average value, need to update this
-    return temporary->update.avg;
-  }
-
   return temporary->listValues.back();
 }
 
-float Measurements::getFloat(MeasurementType type, bool average, int ch) {
+float Measurements::getFloat(MeasurementType type, int ch) {
   // Sanity check to validate channel, assert if invalid
   validateChannel(ch);
 
@@ -290,10 +285,6 @@ float Measurements::getFloat(MeasurementType type, bool average, int ch) {
   if (temporary->listValues.empty()) {
     // Values still empty, return 0
     return 0;
-  }
-
-  if (average) {
-    return temporary->update.avg;
   }
 
   return temporary->listValues.back();

--- a/src/AgValue.h
+++ b/src/AgValue.h
@@ -7,28 +7,28 @@
 
 class Measurements {
 private:
-  // Generic struct for reading indication for respective value
-  // TODO: Reading naming is confusing, because its not actually reading but updating with new value
-  struct Reading {
-    int counter; // How many reading attempts done
-    int success; // How many reading that success from each attempts
-    int max;     // Maximum reading attempt
+  // Generic struct for update indication for respective value
+  struct Update {
+    int counter; // How many update attempts done
+    int success; // How many update value that actually give valid value
+    int max;     // Maximum update before calculating average
   };
 
   // Reading type for sensor value that outputs float
   struct FloatValue {
-    float lastValue; // Last reading value
-    float sumValues; // Total value of each reading
-    float avg;       // The last average calculation after maximum reading attempt reached
-    Reading read;
+    float lastValue; // Last update value
+    float sumValues; // Total value from each update
+    float avg;       // The last average calculation after maximum update attempt reached
+    Update update;
   };
 
   // Reading type for sensor value that outputs integer
   struct IntegerValue {
-    int lastValue;           // Last reading value
-    unsigned long sumValues; // Total value of each reading // TODO: explain why unsigned long
-    int avg;                 // The last average calculation after maximum reading attempt reached
-    Reading read;
+    int lastValue;           // Last update value
+    unsigned long sumValues; // Total value from each update; unsigned long to accomodate TVOx and
+                             // NOx raw data
+    int avg;                 // The last average calculation after maximum update attempt reached
+    Update update;
   };
 
 public:
@@ -71,8 +71,29 @@ public:
     PM03,
   };
 
-  void updateValue(AgValueType type, int val);
-  void updateValue(AgValueType type, float val);
+  /**
+   * @brief update target type value with new value.
+   * Each AgValueType has last raw value and last average that are calculated based on max number of
+   * set This function is for AgValueType that use INT as the data type
+   *
+   * @param type (AgValueType) value type that will be updated
+   * @param val (int) the new value
+   * @return true if update counter reached and new average value is calculated
+   * @return false otherwise
+   */
+  bool updateValue(AgValueType type, int val);
+
+  /**
+   * @brief update target type value with new value.
+   * Each AgValueType has last raw value and last average that are calculated based on max number of
+   * set This function is for AgValueType that use FLOAT as the data type
+   *
+   * @param type (AgValueType) value type that will be updated
+   * @param val (float) the new value
+   * @return true if update counter reached and new average value is calculated
+   * @return false otherwise
+   */
+  bool updateValue(AgValueType type, float val);
 
   float Temperature;
   int Humidity;

--- a/src/AgValue.h
+++ b/src/AgValue.h
@@ -15,13 +15,13 @@ private:
   struct Update {
     int invalidCounter; // Counting on how many invalid value that are passed to update function
     int max;            // Maximum elements on the list
+    float avg;          // Moving average value, updated every update function called
   };
 
   // Reading type for sensor value that outputs float
   struct FloatValue {
     float sumValues; // Total value from each update
     std::vector<float> listValues; // List of update value that are kept
-    float avg;                     // Moving average value, updated every update function called
     Update update;
   };
 
@@ -30,7 +30,6 @@ private:
     unsigned long sumValues; // Total value from each update; unsigned long to accomodate TVOx and
                              // NOx raw data
     std::vector<int> listValues; // List of update value that are kept
-    float avg;                   // Moving average value, updated every update function called
     Update update;
   };
 

--- a/src/AgValue.h
+++ b/src/AgValue.h
@@ -35,32 +35,11 @@ private:
   };
 
 public:
-  Measurements() {
-    pm25_1 = -1;
-    pm01_1 = -1;
-    pm10_1 = -1;
-    pm03PCount_1 = -1;
-    temp_1 = -1001;
-    hum_1 = -1;
-
-    pm25_2 = -1;
-    pm01_2 = -1;
-    pm10_2 = -1;
-    pm03PCount_2 = -1;
-    temp_2 = -1001;
-    hum_2 = -1;
-
-    Temperature = -1001;
-    Humidity = -1;
-    CO2 = -1;
-    TVOC = -1;
-    TVOCRaw = -1;
-    NOx = -1;
-    NOxRaw = -1;
-  }
+  Measurements() {}
   ~Measurements() {}
 
-  enum class AgValueType {
+  // Enumeration for every AG measurements
+  enum MeasurementType {
     Temperature,
     Humidity,
     CO2,
@@ -75,40 +54,40 @@ public:
   };
 
   /**
-   * @brief Set each AgValueType maximum update for a value type before calculate the average
+   * @brief Set each MeasurementType maximum update before calculate the average
    *
-   * @param type the target value type to set
+   * @param type the target measurement type to set
    * @param max the maximum counter
    */
-  void maxUpdate(AgValueType type, int max);
+  void maxUpdate(MeasurementType, int max);
 
   /**
-   * @brief update target type value with new value.
-   * Each AgValueType has last raw value and last average that are calculated based on max number of
-   * update. This function is for AgValueType that use INT as the data type
+   * @brief update target measurement type with new value.
+   * Each MeasurementType has last raw value and last average that are calculated based on max
+   * number of update. This function is for MeasurementType that use INT as the data type
    *
-   * @param type (AgValueType) value type that will be updated
+   * @param type measurement type that will be updated
    * @param val (int) the new value
-   * @param ch (int) the AgValueType channel, not every AgValueType has more than 1 channel.
+   * @param ch (int) the MeasurementType channel, not every MeasurementType has more than 1 channel.
    * Currently maximum channel is 2. Default: 1 (channel 1)
    * @return true if update counter reached and new average value is calculated
    * @return false otherwise
    */
-  bool updateValue(AgValueType type, int val, int ch = 1);
+  bool update(MeasurementType type, int val, int ch = 1);
 
   /**
-   * @brief update target type value with new value.
-   * Each AgValueType has last raw value and last average that are calculated based on max number of
-   * update. This function is for AgValueType that use FLOAT as the data type
+   * @brief update target measurement type with new value.
+   * Each MeasurementType has last raw value and last average that are calculated based on max
+   * number of update. This function is for MeasurementType that use FLOAT as the data type
    *
-   * @param type (AgValueType) value type that will be updated
+   * @param type measurement type that will be updated
    * @param val (float) the new value
-   * @param ch (int) the AgValueType channel, not every AgValueType has more than 1 channel.
+   * @param ch (int) the MeasurementType channel, not every MeasurementType has more than 1 channel.
    * Currently maximum channel is 2. Default: 1 (channel 1)
    * @return true if update counter reached and new average value is calculated
    * @return false otherwise
    */
-  bool updateValue(AgValueType type, float val, int ch = 1);
+  bool update(MeasurementType type, float val, int ch = 1);
 
   /**
    * @brief Get the target measurement type value
@@ -118,7 +97,7 @@ public:
    * @param ch target type value channel
    * @return int measurement type value
    */
-  int getValue(AgValueType type, bool average = true, int ch = 1);
+  int get(MeasurementType type, bool average = true, int ch = 1);
 
   /**
    * @brief Get the target measurement type value
@@ -128,49 +107,13 @@ public:
    * @param ch target type value channel
    * @return float measurement type value
    */
-  float getValueFloat(AgValueType type, bool average = true, int ch = 1);
+  float getFloat(MeasurementType type, bool average = true, int ch = 1);
 
-  float Temperature;
-  int Humidity;
-  int CO2;
-  int TVOC;
-  int TVOCRaw;
-  int NOx;
-  int NOxRaw;
-
-  int pm25_1;
-  int pm01_1;
-  int pm10_1;
-  int pm03PCount_1;
-  float temp_1;
-  int hum_1;
-
-  int pm25_2;
-  int pm01_2;
-  int pm10_2;
-  int pm03PCount_2;
-  float temp_2;
-  int hum_2;
-
-  int pm1Value01;
-  int pm1Value25;
-  int pm1Value10;
-  int pm1PCount;
-  int pm1temp;
-  int pm1hum;
-  int pm2Value01;
-  int pm2Value25;
-  int pm2Value10;
-  int pm2PCount;
-  int pm2temp;
-  int pm2hum;
-  int countPosition;
-  const int targetCount = 20;
+  // TODO: update this to using setter
   int bootCount;
 
-  String toString(bool isLocal, AgFirmwareMode fwMode, int rssi, void *_ag, void *_config);
-  String toStringX(bool localServer, AgFirmwareMode fwMode, int rssi, AirGradient &ag,
-                   Configuration &config);
+  String toString(bool localServer, AgFirmwareMode fwMode, int rssi, AirGradient &ag,
+                  Configuration &config);
 
 private:
   // Some declared as an array (channel), because FW_MODE_O_1PPx has two PMS5003T
@@ -212,7 +155,7 @@ private:
   /**
    * Convert AgValue Type to string representation of the value
    */
-  String agValueTypeStr(AgValueType type);
+  String measurementTypeStr(MeasurementType type);
 
   /**
    * @brief check if provided channel is a valid channel or not

--- a/src/AgValue.h
+++ b/src/AgValue.h
@@ -86,10 +86,12 @@ public:
    *
    * @param type (AgValueType) value type that will be updated
    * @param val (int) the new value
+   * @param ch (int) the AgValueType channel, not every AgValueType has more than 1 channel.
+   * Currently maximum channel is 2. Default: 1 (channel 1)
    * @return true if update counter reached and new average value is calculated
    * @return false otherwise
    */
-  bool updateValue(AgValueType type, int val);
+  bool updateValue(AgValueType type, int val, int ch = 1);
 
   /**
    * @brief update target type value with new value.
@@ -98,10 +100,12 @@ public:
    *
    * @param type (AgValueType) value type that will be updated
    * @param val (float) the new value
+   * @param ch (int) the AgValueType channel, not every AgValueType has more than 1 channel.
+   * Currently maximum channel is 2. Default: 1 (channel 1)
    * @return true if update counter reached and new average value is calculated
    * @return false otherwise
    */
-  bool updateValue(AgValueType type, float val);
+  bool updateValue(AgValueType type, float val, int ch = 1);
 
   float Temperature;
   int Humidity;
@@ -144,17 +148,18 @@ public:
   String toString(bool isLocal, AgFirmwareMode fwMode, int rssi, void *_ag, void *_config);
 
 private:
-  FloatValue _temperature;
-  FloatValue _humidity;
+  // Some declared as an array (channel), because FW_MODE_O_1PPx has two PMS5003T
+  FloatValue _temperature[2];
+  FloatValue _humidity[2];
   IntegerValue _co2;
   IntegerValue _tvoc;
   IntegerValue _tvoc_raw;
   IntegerValue _nox;
   IntegerValue _nox_raw;
-  IntegerValue _pm_25;
-  IntegerValue _pm_01;
-  IntegerValue _pm_10;
-  IntegerValue _pm_03_pc; // particle count 0.3
+  IntegerValue _pm_25[2];
+  IntegerValue _pm_01[2];
+  IntegerValue _pm_10[2];
+  IntegerValue _pm_03_pc[2]; // particle count 0.3
 
   /**
    * @brief Get PMS5003 firmware version string

--- a/src/AgValue.h
+++ b/src/AgValue.h
@@ -35,6 +35,41 @@ public:
   }
   ~Measurements() {}
 
+  // Generic struct for reading indication for respective value
+  struct Reading {
+    int counter; // How many reading attempts done
+    int success; // How many reading that success from each attempts
+    int max;     // Maximum reading attempt
+  };
+
+  // Reading type for sensor value that outputs float
+  struct FloatValue {
+    float lastValue; // Last reading value
+    float sumValues; // Total value of each reading
+    float avg;       // The last average calculation after maximum reading attempt reached
+    Reading read;
+  };
+
+  // Reading type for sensor value that outputs integer
+  struct IntegerValue {
+    int lastValue;           // Last reading value
+    unsigned long sumValues; // Total value of each reading
+    int avg;                 // The last average calculation after maximum reading attempt reached
+    Reading read;
+  };
+
+  FloatValue temperature;
+  FloatValue humidity;
+  IntegerValue co2;
+  IntegerValue tvoc;
+  IntegerValue tvoc_raw;
+  IntegerValue nox;
+  IntegerValue nox_raw;
+  IntegerValue pm_25;
+  IntegerValue pm_01;
+  IntegerValue pm_10;
+  IntegerValue pm_03_pc;
+
   float Temperature;
   int Humidity;
   int CO2;

--- a/src/AgValue.h
+++ b/src/AgValue.h
@@ -1,7 +1,10 @@
 #ifndef _AG_VALUE_H_
 #define _AG_VALUE_H_
 
+#include "AgConfigure.h"
+#include "AirGradient.h"
 #include "App/AppDef.h"
+#include "Libraries/Arduino_JSON/src/Arduino_JSON.h"
 #include "Main/utils.h"
 #include <Arduino.h>
 
@@ -166,6 +169,8 @@ public:
   int bootCount;
 
   String toString(bool isLocal, AgFirmwareMode fwMode, int rssi, void *_ag, void *_config);
+  String toStringX(bool localServer, AgFirmwareMode fwMode, int rssi, AirGradient &ag,
+                   Configuration &config);
 
 private:
   // Some declared as an array (channel), because FW_MODE_O_1PPx has two PMS5003T
@@ -214,6 +219,11 @@ private:
    * abort program if invalid
    */
   void validateChannel(int ch);
+
+  JSONVar buildOutdoor(bool localServer, AgFirmwareMode fwMode, AirGradient &ag,
+                       Configuration &config);
+  JSONVar buildIndoor(bool localServer, AirGradient &ag, Configuration &config);
+  JSONVar buildPMS(AirGradient &ag, int ch, bool allCh, bool withTempHum, bool compensate);
 };
 
 #endif /** _AG_VALUE_H_ */

--- a/src/AgValue.h
+++ b/src/AgValue.h
@@ -11,7 +11,7 @@ private:
   struct Update {
     int counter; // How many update attempts done
     int success; // How many update value that actually give valid value
-    int max;     // Maximum update before calculating average
+    int max;     // Maximum update counter before calculating average
   };
 
   // Reading type for sensor value that outputs float
@@ -68,15 +68,21 @@ public:
     PM25,
     PM01,
     PM10,
-    PM03,
+    PM03_PC,
   };
 
-  void init();
+  /**
+   * @brief Set each AgValueType maximum update for a value type before calculate the average
+   *
+   * @param type the target value type to set
+   * @param max the maximum counter
+   */
+  void maxUpdate(AgValueType type, int max);
 
   /**
    * @brief update target type value with new value.
    * Each AgValueType has last raw value and last average that are calculated based on max number of
-   * set This function is for AgValueType that use INT as the data type
+   * update. This function is for AgValueType that use INT as the data type
    *
    * @param type (AgValueType) value type that will be updated
    * @param val (int) the new value
@@ -88,7 +94,7 @@ public:
   /**
    * @brief update target type value with new value.
    * Each AgValueType has last raw value and last average that are calculated based on max number of
-   * set This function is for AgValueType that use FLOAT as the data type
+   * update. This function is for AgValueType that use FLOAT as the data type
    *
    * @param type (AgValueType) value type that will be updated
    * @param val (float) the new value

--- a/src/AgValue.h
+++ b/src/AgValue.h
@@ -69,7 +69,7 @@ public:
    * @param val (int) the new value
    * @param ch (int) the MeasurementType channel, not every MeasurementType has more than 1 channel.
    * Currently maximum channel is 2. Default: 1 (channel 1)
-   * @return false if new value invalid consecutively reach threshold
+   * @return false if new value invalid consecutively reach threshold (max period)
    * @return true otherwise
    */
   bool update(MeasurementType type, int val, int ch = 1);
@@ -83,7 +83,7 @@ public:
    * @param val (float) the new value
    * @param ch (int) the MeasurementType channel, not every MeasurementType has more than 1 channel.
    * Currently maximum channel is 2. Default: 1 (channel 1)
-   * @return false if new value invalid consecutively reach threshold
+   * @return false if new value invalid consecutively reach threshold (max period)
    * @return true otherwise
    */
   bool update(MeasurementType type, float val, int ch = 1);

--- a/src/AgValue.h
+++ b/src/AgValue.h
@@ -208,6 +208,12 @@ private:
    * Convert AgValue Type to string representation of the value
    */
   String agValueTypeStr(AgValueType type);
+
+  /**
+   * @brief check if provided channel is a valid channel or not
+   * abort program if invalid
+   */
+  void validateChannel(int ch);
 };
 
 #endif /** _AG_VALUE_H_ */

--- a/src/AgValue.h
+++ b/src/AgValue.h
@@ -42,14 +42,14 @@ public:
     Temperature,
     Humidity,
     CO2,
-    TVOC,
+    TVOC, // index value
     TVOCRaw,
-    NOx,
+    NOx, // index value
     NOxRaw,
     PM25,
     PM01,
     PM10,
-    PM03_PC,
+    PM03_PC, // Particle count
   };
 
   /**
@@ -125,9 +125,9 @@ private:
   FloatValue _temperature[2];
   FloatValue _humidity[2];
   IntegerValue _co2;
-  IntegerValue _tvoc;
+  IntegerValue _tvoc; // Index value
   IntegerValue _tvoc_raw;
-  IntegerValue _nox;
+  IntegerValue _nox; // Index value
   IntegerValue _nox_raw;
   IntegerValue _pm_25[2];
   IntegerValue _pm_01[2];

--- a/src/AgValue.h
+++ b/src/AgValue.h
@@ -1,14 +1,36 @@
 #ifndef _AG_VALUE_H_
 #define _AG_VALUE_H_
 
-#include <Arduino.h>
 #include "App/AppDef.h"
+#include "Main/utils.h"
+#include <Arduino.h>
 
 class Measurements {
 private:
-  String pms5003FirmwareVersion(int fwCode);
-  String pms5003TFirmwareVersion(int fwCode);
-  String pms5003FirmwareVersionBase(String prefix, int fwCode);
+  // Generic struct for reading indication for respective value
+  // TODO: Reading naming is confusing, because its not actually reading but updating with new value
+  struct Reading {
+    int counter; // How many reading attempts done
+    int success; // How many reading that success from each attempts
+    int max;     // Maximum reading attempt
+  };
+
+  // Reading type for sensor value that outputs float
+  struct FloatValue {
+    float lastValue; // Last reading value
+    float sumValues; // Total value of each reading
+    float avg;       // The last average calculation after maximum reading attempt reached
+    Reading read;
+  };
+
+  // Reading type for sensor value that outputs integer
+  struct IntegerValue {
+    int lastValue;           // Last reading value
+    unsigned long sumValues; // Total value of each reading // TODO: explain why unsigned long
+    int avg;                 // The last average calculation after maximum reading attempt reached
+    Reading read;
+  };
+
 public:
   Measurements() {
     pm25_1 = -1;
@@ -35,40 +57,22 @@ public:
   }
   ~Measurements() {}
 
-  // Generic struct for reading indication for respective value
-  struct Reading {
-    int counter; // How many reading attempts done
-    int success; // How many reading that success from each attempts
-    int max;     // Maximum reading attempt
+  enum class AgValueType {
+    Temperature,
+    Humidity,
+    CO2,
+    TVOC,
+    TVOCRaw,
+    NOx,
+    NOxRaw,
+    PM25,
+    PM01,
+    PM10,
+    PM03,
   };
 
-  // Reading type for sensor value that outputs float
-  struct FloatValue {
-    float lastValue; // Last reading value
-    float sumValues; // Total value of each reading
-    float avg;       // The last average calculation after maximum reading attempt reached
-    Reading read;
-  };
-
-  // Reading type for sensor value that outputs integer
-  struct IntegerValue {
-    int lastValue;           // Last reading value
-    unsigned long sumValues; // Total value of each reading
-    int avg;                 // The last average calculation after maximum reading attempt reached
-    Reading read;
-  };
-
-  FloatValue temperature;
-  FloatValue humidity;
-  IntegerValue co2;
-  IntegerValue tvoc;
-  IntegerValue tvoc_raw;
-  IntegerValue nox;
-  IntegerValue nox_raw;
-  IntegerValue pm_25;
-  IntegerValue pm_01;
-  IntegerValue pm_10;
-  IntegerValue pm_03_pc;
+  void updateValue(AgValueType type, int val);
+  void updateValue(AgValueType type, float val);
 
   float Temperature;
   int Humidity;
@@ -108,7 +112,25 @@ public:
   const int targetCount = 20;
   int bootCount;
 
-  String toString(bool isLocal, AgFirmwareMode fwMode, int rssi, void* _ag, void* _config);
+  String toString(bool isLocal, AgFirmwareMode fwMode, int rssi, void *_ag, void *_config);
+
+private:
+  FloatValue _temperature;
+  FloatValue _humidity;
+  IntegerValue _co2;
+  IntegerValue _tvoc;
+  IntegerValue _tvoc_raw;
+  IntegerValue _nox;
+  IntegerValue _nox_raw;
+  IntegerValue _pm_25;
+  IntegerValue _pm_01;
+  IntegerValue _pm_10;
+  IntegerValue _pm_03_pc; // particle count 0.3
+
+  String pms5003FirmwareVersion(int fwCode);
+  String pms5003TFirmwareVersion(int fwCode);
+  String pms5003FirmwareVersionBase(String prefix, int fwCode);
+  String agValueTypeStr(AgValueType type);
 };
 
 #endif /** _AG_VALUE_H_ */

--- a/src/AgValue.h
+++ b/src/AgValue.h
@@ -14,7 +14,7 @@ private:
   // Generic struct for update indication for respective value
   struct Update {
     int invalidCounter; // Counting on how many invalid value that are passed to update function
-    int max;            // Maximum elements on the list
+    int max;            // Maximum length of the period of the moving average
     float avg;          // Moving average value, updated every update function called
   };
 
@@ -53,60 +53,58 @@ public:
   };
 
   /**
-   * @brief Set each MeasurementType maximum update before calculate the average
+   * @brief Set each MeasurementType maximum period length for moving average
    *
    * @param type the target measurement type to set
-   * @param max the maximum counter
+   * @param max the maximum period length
    */
   void maxUpdate(MeasurementType, int max);
 
   /**
    * @brief update target measurement type with new value.
-   * Each MeasurementType has last raw value and last average that are calculated based on max
-   * number of update. This function is for MeasurementType that use INT as the data type
+   * Each MeasurementType has last raw value and moving average value based on max period
+   * This function is for MeasurementType that use INT as the data type
    *
    * @param type measurement type that will be updated
    * @param val (int) the new value
    * @param ch (int) the MeasurementType channel, not every MeasurementType has more than 1 channel.
    * Currently maximum channel is 2. Default: 1 (channel 1)
-   * @return true if update counter reached and new average value is calculated
-   * @return false otherwise
+   * @return false if new value invalid consecutively reach threshold
+   * @return true otherwise
    */
   bool update(MeasurementType type, int val, int ch = 1);
 
   /**
    * @brief update target measurement type with new value.
-   * Each MeasurementType has last raw value and last average that are calculated based on max
-   * number of update. This function is for MeasurementType that use FLOAT as the data type
+   * Each MeasurementType has last raw value and moving average value based on max period
+   * This function is for MeasurementType that use FLOAT as the data type
    *
    * @param type measurement type that will be updated
    * @param val (float) the new value
    * @param ch (int) the MeasurementType channel, not every MeasurementType has more than 1 channel.
    * Currently maximum channel is 2. Default: 1 (channel 1)
-   * @return true if update counter reached and new average value is calculated
-   * @return false otherwise
+   * @return false if new value invalid consecutively reach threshold
+   * @return true otherwise
    */
   bool update(MeasurementType type, float val, int ch = 1);
 
   /**
-   * @brief Get the target measurement type value
+   * @brief Get the target measurement latest value
    *
    * @param type measurement type that will be retrieve
-   * @param average true if expect last average value, false if expect last update value
    * @param ch target type value channel
    * @return int measurement type value
    */
-  int get(MeasurementType type, bool average = true, int ch = 1);
+  int get(MeasurementType type, int ch = 1);
 
   /**
-   * @brief Get the target measurement type value
+   * @brief Get the target measurement latest value
    *
    * @param type measurement type that will be retrieve
-   * @param average true if expect last average value, false if expect last update value
    * @param ch target type value channel
    * @return float measurement type value
    */
-  float getFloat(MeasurementType type, bool average = true, int ch = 1);
+  float getFloat(MeasurementType type, int ch = 1);
 
   // TODO: update this to using setter
   int bootCount;

--- a/src/AgValue.h
+++ b/src/AgValue.h
@@ -7,30 +7,30 @@
 #include "Libraries/Arduino_JSON/src/Arduino_JSON.h"
 #include "Main/utils.h"
 #include <Arduino.h>
+#include <vector>
 
 class Measurements {
 private:
   // Generic struct for update indication for respective value
   struct Update {
-    int counter; // How many update attempts done
-    int success; // How many update value that actually give valid value
-    int max;     // Maximum update counter before calculating average
+    int invalidCounter; // Counting on how many invalid value that are passed to update function
+    int max;            // Maximum elements on the list
   };
 
   // Reading type for sensor value that outputs float
   struct FloatValue {
-    float lastValue; // Last update value
     float sumValues; // Total value from each update
-    float avg;       // The last average calculation after maximum update attempt reached
+    std::vector<float> listValues; // List of update value that are kept
+    float avg;                     // Moving average value, updated every update function called
     Update update;
   };
 
   // Reading type for sensor value that outputs integer
   struct IntegerValue {
-    int lastValue;           // Last update value
     unsigned long sumValues; // Total value from each update; unsigned long to accomodate TVOx and
                              // NOx raw data
-    int avg;                 // The last average calculation after maximum update attempt reached
+    std::vector<int> listValues; // List of update value that are kept
+    float avg;                   // Moving average value, updated every update function called
     Update update;
   };
 

--- a/src/AgValue.h
+++ b/src/AgValue.h
@@ -106,11 +106,19 @@ public:
    */
   float getFloat(MeasurementType type, int ch = 1);
 
-  // TODO: update this to using setter
-  int bootCount;
-
+  /**
+   * build json payload for every measurements
+   */
   String toString(bool localServer, AgFirmwareMode fwMode, int rssi, AirGradient &ag,
                   Configuration &config);
+
+  /**
+   * Set to true if want to debug every update value
+   */
+  void setDebug(bool debug);
+
+  // TODO: update this to use setter
+  int bootCount;
 
 private:
   // Some declared as an array (channel), because FW_MODE_O_1PPx has two PMS5003T
@@ -125,6 +133,8 @@ private:
   IntegerValue _pm_01[2];
   IntegerValue _pm_10[2];
   IntegerValue _pm_03_pc[2]; // particle count 0.3
+
+  bool _debug = false;
 
   /**
    * @brief Get PMS5003 firmware version string

--- a/src/AgValue.h
+++ b/src/AgValue.h
@@ -71,6 +71,8 @@ public:
     PM03,
   };
 
+  void init();
+
   /**
    * @brief update target type value with new value.
    * Each AgValueType has last raw value and last average that are calculated based on max number of
@@ -148,9 +150,32 @@ private:
   IntegerValue _pm_10;
   IntegerValue _pm_03_pc; // particle count 0.3
 
+  /**
+   * @brief Get PMS5003 firmware version string
+   *
+   * @param fwCode
+   * @return String
+   */
   String pms5003FirmwareVersion(int fwCode);
+  /**
+   * @brief Get PMS5003T firmware version string
+   *
+   * @param fwCode
+   * @return String
+   */
   String pms5003TFirmwareVersion(int fwCode);
+  /**
+   * @brief Get firmware version string
+   *
+   * @param prefix Prefix firmware string
+   * @param fwCode Version code
+   * @return string
+   */
   String pms5003FirmwareVersionBase(String prefix, int fwCode);
+
+  /**
+   * Convert AgValue Type to string representation of the value
+   */
   String agValueTypeStr(AgValueType type);
 };
 

--- a/src/AgValue.h
+++ b/src/AgValue.h
@@ -107,6 +107,26 @@ public:
    */
   bool updateValue(AgValueType type, float val, int ch = 1);
 
+  /**
+   * @brief Get the target measurement type value
+   *
+   * @param type measurement type that will be retrieve
+   * @param average true if expect last average value, false if expect last update value
+   * @param ch target type value channel
+   * @return int measurement type value
+   */
+  int getValue(AgValueType type, bool average = true, int ch = 1);
+
+  /**
+   * @brief Get the target measurement type value
+   *
+   * @param type measurement type that will be retrieve
+   * @param average true if expect last average value, false if expect last update value
+   * @param ch target type value channel
+   * @return float measurement type value
+   */
+  float getValueFloat(AgValueType type, bool average = true, int ch = 1);
+
   float Temperature;
   int Humidity;
   int CO2;

--- a/src/AgValue.h
+++ b/src/AgValue.h
@@ -58,7 +58,7 @@ public:
    * @param type the target measurement type to set
    * @param max the maximum period length
    */
-  void maxUpdate(MeasurementType, int max);
+  void maxPeriod(MeasurementType, int max);
 
   /**
    * @brief update target measurement type with new value.

--- a/src/PMS/PMS.cpp
+++ b/src/PMS/PMS.cpp
@@ -322,11 +322,12 @@ int PMSBase::pm25ToAQI(int pm02) {
  *
  * @param pm25 Raw PM2.5 value
  * @param humidity Humidity value (%)
- * @return int
+ * @return compensated pm25 value
  */
-int PMSBase::compensate(int pm25, float humidity) {
+float PMSBase::compensate(float pm25, float humidity) {
   float value;
-  float fpm25 = pm25;
+
+  // Correct invalid humidity value
   if (humidity < 0) {
     humidity = 0;
   }
@@ -334,23 +335,33 @@ int PMSBase::compensate(int pm25, float humidity) {
     humidity = 100.0f;
   }
 
-  if(pm25 < 30) { /** pm2.5 < 30 */
-    value = (fpm25 * 0.524f) - (humidity * 0.0862f) + 5.75f;
-  } else if(pm25 < 50) { /** 30 <= pm2.5 < 50 */
-    value = (0.786f * (fpm25 * 0.05f - 1.5f) + 0.524f * (1.0f - (fpm25 * 0.05f - 1.5f))) * fpm25 - (0.0862f * humidity) + 5.75f;
-  } else if(pm25 < 210) { /** 50 <= pm2.5 < 210 */
-    value = (0.786f * fpm25) - (0.0862f * humidity) + 5.75f;
-  } else if(pm25 < 260) { /** 210 <= pm2.5 < 260 */
-    value = (0.69f * (fpm25 * 0.02f - 4.2f) + 0.786f * (1.0f - (fpm25 * 0.02f - 4.2f))) * fpm25 - (0.0862f * humidity * (1.0f - (fpm25 * 0.02f - 4.2f))) + (2.966f * (fpm25 * 0.02f - 4.2f)) + (5.75f * (1.0f - (fpm25 * 0.02f - 4.2f))) + (8.84f * (1.e-4) * fpm25 * fpm25 * (fpm25 * 0.02f - 4.2f));
+  // If its already 0, do not proceed
+  if (pm25 == 0) {
+    return 0.0;
+  }
+
+  if (pm25 < 30) { /** pm2.5 < 30 */
+    value = (pm25 * 0.524f) - (humidity * 0.0862f) + 5.75f;
+  } else if (pm25 < 50) { /** 30 <= pm2.5 < 50 */
+    value = (0.786f * (pm25 * 0.05f - 1.5f) + 0.524f * (1.0f - (pm25 * 0.05f - 1.5f))) * pm25 -
+            (0.0862f * humidity) + 5.75f;
+  } else if (pm25 < 210) { /** 50 <= pm2.5 < 210 */
+    value = (0.786f * pm25) - (0.0862f * humidity) + 5.75f;
+  } else if (pm25 < 260) { /** 210 <= pm2.5 < 260 */
+    value = (0.69f * (pm25 * 0.02f - 4.2f) + 0.786f * (1.0f - (pm25 * 0.02f - 4.2f))) * pm25 -
+            (0.0862f * humidity * (1.0f - (pm25 * 0.02f - 4.2f))) +
+            (2.966f * (pm25 * 0.02f - 4.2f)) + (5.75f * (1.0f - (pm25 * 0.02f - 4.2f))) +
+            (8.84f * (1.e-4) * pm25 * pm25 * (pm25 * 0.02f - 4.2f));
   } else { /** 260 <= pm2.5 */
-    value = 2.966f + (0.69f * fpm25) + (8.84f * (1.e-4) * fpm25 * fpm25);
+    value = 2.966f + (0.69f * pm25) + (8.84f * (1.e-4) * pm25 * pm25);
   }
 
+  // No negative value for pm2.5
   if (value < 0) {
-    value = 0;
+    return 0.0;
   }
 
-  return (int)value;
+  return value;
 }
 
 /**

--- a/src/PMS/PMS.h
+++ b/src/PMS/PMS.h
@@ -39,7 +39,7 @@ public:
   uint8_t getErrorCode(void);
 
   int pm25ToAQI(int pm02);
-  int compensate(int pm25, float humidity);
+  float compensate(float pm25, float humidity);
 
 private:
   static const uint8_t package_size = 32;

--- a/src/PMS/PMS5003.cpp
+++ b/src/PMS/PMS5003.cpp
@@ -118,16 +118,14 @@ int PMS5003::convertPm25ToUsAqi(int pm25) { return pms.pm25ToAQI(pm25); }
 
 /**
  * @brief Correct PM2.5
- * 
+ *
  * Reference formula: https://www.airgradient.com/documentation/correction-algorithms/
- * 
+ *
  * @param pm25 PM2.5 raw value
  * @param humidity Humidity value
- * @return int 
+ * @return compensated value in float
  */
-int PMS5003::compensate(int pm25, float humidity) {
-  return pms.compensate(pm25, humidity);
-}
+float PMS5003::compensate(float pm25, float humidity) { return pms.compensate(pm25, humidity); }
 
 /**
  * @brief Get sensor firmware version

--- a/src/PMS/PMS5003.h
+++ b/src/PMS/PMS5003.h
@@ -30,7 +30,7 @@ public:
   int getPm10Ae(void);
   int getPm03ParticleCount(void);
   int convertPm25ToUsAqi(int pm25);
-  int compensate(int pm25, float humidity);
+  float compensate(float pm25, float humidity);
   int getFirmwareVersion(void);
   uint8_t getErrorCode(void);
   bool connected(void);

--- a/src/PMS/PMS5003T.cpp
+++ b/src/PMS/PMS5003T.cpp
@@ -165,16 +165,14 @@ float PMS5003T::getRelativeHumidity(void) {
 
 /**
  * @brief Correct PM2.5
- * 
+ *
  * Reference formula: https://www.airgradient.com/documentation/correction-algorithms/
- * 
+ *
  * @param pm25 PM2.5 raw value
  * @param humidity Humidity value
- * @return int 
+ * @return compensated value
  */
-int PMS5003T::compensate(int pm25, float humidity) {
-  return pms.compensate(pm25, humidity);
-}
+float PMS5003T::compensate(float pm25, float humidity) { return pms.compensate(pm25, humidity); }
 
 /**
  * @brief Get module(s) firmware version

--- a/src/PMS/PMS5003T.h
+++ b/src/PMS/PMS5003T.h
@@ -35,7 +35,7 @@ public:
   int convertPm25ToUsAqi(int pm25);
   float getTemperature(void);
   float getRelativeHumidity(void);
-  int compensate(int pm25, float humidity);
+  float compensate(float pm25, float humidity);
   int getFirmwareVersion(void);
   uint8_t getErrorCode(void);
   bool connected(void);


### PR DESCRIPTION
# Changes

Main changes is restructuring Measurement class on AgValue files. Each measurements has average value that are always calculated based on max period length (`calculateMaxPeriod()`) set for moving average calculation.

## Other includes

1. Every measurements data from each sensor have an average value which are sent to AirGradient server, MQTT and Local Server fetch. On oled display and led bar indication still using last reading value.
2. Relative humidity now is in float 2 decimals precision (except showing on oled display)
3. Remove ESP restart when PM sensor read failed on _X_ times
4. Interval for SHT sensor reading now set to 6s
5. Optional debug every reading interval to serial monitor. Sensor debug to serial monitor is the moving average value
6. `PMSBase::compensate` using `float`  data type for arguments and return (previously `int`).
    - Directly return 0 when PM value is 0
8. Send indication when consecutively update invalid value 