### PR TITLE
(Basic DIY): Fix temperature parsing in OLED and debug for Basic DIY version

### DIFF
--- a/src/AgOledDisplay.cpp
+++ b/src/AgOledDisplay.cpp
@@ -394,7 +394,7 @@ void OledDisplay::showDashboard(const char *status) {
       if (config.isTemperatureUnitInF()) {
         snprintf(strBuf, sizeof(strBuf), "T:%0.1f F", utils::degreeC_To_F(temp));
       } else {
-        snprintf(strBuf, sizeof(strBuf), "T:%0.f1 C", temp);
+        snprintf(strBuf, sizeof(strBuf), "T:%0.1f C", temp);
       }
     } else {
       if (config.isTemperatureUnitInF()) {

--- a/src/AgValue.cpp
+++ b/src/AgValue.cpp
@@ -189,7 +189,7 @@ bool Measurements::update(MeasurementType type, int val, int ch) {
 
   // Sanity check if measurement type is defined for integer data type or not
   if (temporary == nullptr) {
-    Serial.printf("%s is not defined for integer data type\n", measurementTypeStr(type));
+    Serial.printf("%s is not defined for integer data type\n", measurementTypeStr(type).c_str());
     // TODO: Just assert?
     return false;
   }
@@ -228,7 +228,7 @@ bool Measurements::update(MeasurementType type, int val, int ch) {
   // Calculate average based on how many elements on the list
   temporary->update.avg = temporary->sumValues / (float)temporary->listValues.size();
   if (_debug) {
-    Serial.printf("%s{%d}: %.2f\n", measurementTypeStr(type), ch, temporary->update.avg);
+    Serial.printf("%s{%d}: %.2f\n", measurementTypeStr(type).c_str(), ch, temporary->update.avg);
   }
 
   return true;
@@ -260,7 +260,7 @@ bool Measurements::update(MeasurementType type, float val, int ch) {
 
   // Sanity check if measurement type is defined for float data type or not
   if (temporary == nullptr) {
-    Serial.printf("%s is not defined for float data type\n", measurementTypeStr(type));
+    Serial.printf("%s is not defined for float data type\n", measurementTypeStr(type).c_str());
     // TODO: Just assert?
     return false;
   }
@@ -299,7 +299,7 @@ bool Measurements::update(MeasurementType type, float val, int ch) {
   // Calculate average based on how many elements on the list
   temporary->update.avg = temporary->sumValues / (float)temporary->listValues.size();
   if (_debug) {
-    Serial.printf("%s{%d}: %.2f\n", measurementTypeStr(type), ch, temporary->update.avg);
+    Serial.printf("%s{%d}: %.2f\n", measurementTypeStr(type).c_str(), ch, temporary->update.avg);
   }
 
   return true;
@@ -348,7 +348,7 @@ int Measurements::get(MeasurementType type, int ch) {
 
   // Sanity check if measurement type is defined for integer data type or not
   if (temporary == nullptr) {
-    Serial.printf("%s is not defined for integer data type\n", measurementTypeStr(type));
+    Serial.printf("%s is not defined for integer data type\n", measurementTypeStr(type).c_str());
     // TODO: Just assert?
     return false;
   }
@@ -383,7 +383,7 @@ float Measurements::getFloat(MeasurementType type, int ch) {
 
   // Sanity check if measurement type is defined for float data type or not
   if (temporary == nullptr) {
-    Serial.printf("%s is not defined for float data type\n", measurementTypeStr(type));
+    Serial.printf("%s is not defined for float data type\n", measurementTypeStr(type).c_str());
     // TODO: Just assert?
     return false;
   }
@@ -434,7 +434,7 @@ float Measurements::getAverage(MeasurementType type, int ch) {
 
   // Sanity check if measurement type is not defined 
   if (measurementAverage == -1000) {
-    Serial.printf("ERROR! %s is not defined on get average value function\n", measurementTypeStr(type));
+    Serial.printf("ERROR! %s is not defined on get average value function\n", measurementTypeStr(type).c_str());
     delay(1000);
     assert(0);
   }


### PR DESCRIPTION
1. In Basic DYI version of AirGradient, temperature is displayed incorrectly in the OLED screen.
Current display: `T:241 C`, Correct display `T:24.8 C`.

2. In debug logs, some `Serial.printf` calls pass through `String` type instead of `char *`. This is visible only on longer messages, such as `Temperature`.
Current log: 
`�|�?{1}: 24.17
Humidity{1}: 55.97`
After changes: 
`Temperature{1}: 24.17
Humidity{1}: 55.97`