### PR TITLE
Fully disable cloud connection to airgradient server option

### DIFF
--- a/docs/local-server.md
+++ b/docs/local-server.md
@@ -160,8 +160,8 @@ If the monitor is set up on the AirGradient dashboard, it will also receive the 
 
 **Notes**
 
-- `offlineMode` : device will disable all network operation, and only show measurements on display and ledbar; Read-Only; change can be apply using reset button on boot.
-- `disableCloudConnection` : disable every request to airgradient server, means feature like post data to airgradient dashboard, configure from cloud and firmware update are disabled. This configuration override `configurationControl` and `postDataToAirGradient`; Read-Only; change can be apply from wifi setup webpage.
+- `offlineMode` : device will disable all network operation, and only show measurements on display and ledbar; Read-Only; Change can be apply using reset button on boot.
+- `disableCloudConnection` : disable every request to AirGradient server, means features like post data to AirGradient server, configuration from AirGradient server and automatic firmware updates are disabled. This configuration overrides `configurationControl` and `postDataToAirGradient`; Read-Only; Change can be apply from wifi setup webpage.
 
 #### Corrections
 

--- a/docs/local-server.md
+++ b/docs/local-server.md
@@ -154,11 +154,14 @@ If the monitor is set up on the AirGradient dashboard, it will also receive the 
 | `ledBarTestRequested`             | Can be set to trigger a test.                                    | Boolean | `true` : LEDs will run test sequence                                                                                                    | `{"ledBarTestRequested": true}`                 |
 | `noxLearningOffset`               | Set NOx learning gain offset.                                    | Number  | 0-720 (default 12)                                                                                                                      | `{"noxLearningOffset": 12}`                     |
 | `tvocLearningOffset`              | Set VOC learning gain offset.                                    | Number  | 0-720 (default 12)                                                                                                                      | `{"tvocLearningOffset": 12}`                    |
-| `offlineMode`                     | Set monitor to run without WiFi.                                 | Boolean |  `false`: Disabled (default) <br> `true`: Enabled                                                                                       | `{"offlineMode": true}`                         |
 | `monitorDisplayCompensatedValues` | Set the display show the PM value with/without compensate  value (only on [3.1.9]()) | Boolean | `false`: Without compensate (default) <br> `true`: with compensate                                                                      | `{"monitorDisplayCompensatedValues": false }`   |
 | `corrections`                     | Sets correction options to display and measurement values on local server response. (version >= [3.1.11]())    | Object |  _see corrections section_             | _see corrections section_                         |
 
 
+**Notes**
+
+- `offlineMode` : device will disable all network operation, and only show measurements on display and ledbar; Read-Only; change can be apply using reset button on boot.
+- `disableCloudConnection` : disable every request to airgradient server, means feature like post data to airgradient dashboard, configure from cloud and firmware update are disabled. This configuration override `configurationControl` and `postDataToAirGradient`; Read-Only; change can be apply from wifi setup webpage.
 
 #### Corrections
 

--- a/docs/local-server.md
+++ b/docs/local-server.md
@@ -160,7 +160,7 @@ If the monitor is set up on the AirGradient dashboard, it will also receive the 
 
 **Notes**
 
-- `offlineMode` : device will disable all network operation, and only show measurements on display and ledbar; Read-Only; Change can be apply using reset button on boot.
+- `offlineMode` : the device will disable all network operation, and only show measurements on the display and ledbar; Read-Only; Change can be apply using reset button on boot.
 - `disableCloudConnection` : disable every request to AirGradient server, means features like post data to AirGradient server, configuration from AirGradient server and automatic firmware updates are disabled. This configuration overrides `configurationControl` and `postDataToAirGradient`; Read-Only; Change can be apply from wifi setup webpage.
 
 #### Corrections

--- a/examples/BASIC/BASIC.ino
+++ b/examples/BASIC/BASIC.ino
@@ -533,7 +533,7 @@ static void sendDataToServer(void) {
   measurements.setBootCount(bootCount);
 
   if (configuration.isOfflineMode() || !configuration.isPostDataToAirGradient()) {
-    Serial.println("Ignore send data to server. Either mode is offline "
+    Serial.println("Skipping transmission of data to AG server. Either mode is offline "
                    "or post data to server disabled");
     return;
   }

--- a/examples/BASIC/BASIC.ino
+++ b/examples/BASIC/BASIC.ino
@@ -539,7 +539,7 @@ static void sendDataToServer(void) {
   }
 
   if (wifiConnector.isConnected() == false) {
-    Serial.println("WiFi not connected, skip post data to server");
+    Serial.println("WiFi not connected, skipping data transmission to AG server");
     return;
   }
 

--- a/examples/BASIC/BASIC.ino
+++ b/examples/BASIC/BASIC.ino
@@ -154,7 +154,7 @@ void setup() {
           apiClient.fetchServerConfiguration();
         }
         configSchedule.update();
-        if (apiClient.isFetchConfigureFailed()) {
+        if (apiClient.isFetchConfigurationFailed()) {
           if (apiClient.isNotAvailableOnDashboard()) {
             stateMachine.displaySetAddToDashBoard();
             stateMachine.displayHandle(
@@ -422,7 +422,7 @@ static void configurationUpdateSchedule(void) {
       configuration.getConfigurationControl() == ConfigurationControl::ConfigurationControlLocal) {
     Serial.println("Ignore fetch server configuration. Either mode is offline "
                    "or configurationControl set to local");
-    apiClient.resetFetchConfigureState();
+    apiClient.resetFetchConfigurationStatus();
     return;
   }
 
@@ -483,7 +483,7 @@ static void appDispHandler(void) {
   if (configuration.isOfflineMode() == false) {
     if (wifiConnector.isConnected() == false) {
       state = AgStateMachineWiFiLost;
-    } else if (apiClient.isFetchConfigureFailed()) {
+    } else if (apiClient.isFetchConfigurationFailed()) {
       state = AgStateMachineSensorConfigFailed;
       if (apiClient.isNotAvailableOnDashboard()) {
         stateMachine.displaySetAddToDashBoard();

--- a/examples/BASIC/OpenMetrics.cpp
+++ b/examples/BASIC/OpenMetrics.cpp
@@ -43,7 +43,7 @@ String OpenMetrics::getPayload(void) {
              "1 if the AirGradient device was able to successfully fetch its "
              "configuration from the server",
              "gauge");
-  add_metric_point("", apiClient.isFetchConfigureFailed() ? "0" : "1");
+  add_metric_point("", apiClient.isFetchConfigurationFailed() ? "0" : "1");
 
   add_metric(
       "post_ok",

--- a/examples/DiyProIndoorV3_3/DiyProIndoorV3_3.ino
+++ b/examples/DiyProIndoorV3_3/DiyProIndoorV3_3.ino
@@ -591,7 +591,7 @@ static void sendDataToServer(void) {
   }
 
   if (wifiConnector.isConnected() == false) {
-    Serial.println("WiFi not connected, skip post data to server");
+    Serial.println("WiFi not connected, skipping data transmission to AG server");
     return;
   }
 

--- a/examples/DiyProIndoorV3_3/DiyProIndoorV3_3.ino
+++ b/examples/DiyProIndoorV3_3/DiyProIndoorV3_3.ino
@@ -154,7 +154,7 @@ void setup() {
           apiClient.fetchServerConfiguration();
         }
         configSchedule.update();
-        if (apiClient.isFetchConfigureFailed()) {
+        if (apiClient.isFetchConfigurationFailed()) {
           if (apiClient.isNotAvailableOnDashboard()) {
             stateMachine.displaySetAddToDashBoard();
             stateMachine.displayHandle(
@@ -474,7 +474,7 @@ static void configurationUpdateSchedule(void) {
       configuration.getConfigurationControl() == ConfigurationControl::ConfigurationControlLocal) {
     Serial.println("Ignore fetch server configuration. Either mode is offline "
                    "or configurationControl set to local");
-    apiClient.resetFetchConfigureState();
+    apiClient.resetFetchConfigurationStatus();
     return;
   }
 
@@ -535,7 +535,7 @@ static void appDispHandler(void) {
   if (configuration.isOfflineMode() == false) {
     if (wifiConnector.isConnected() == false) {
       state = AgStateMachineWiFiLost;
-    } else if (apiClient.isFetchConfigureFailed()) {
+    } else if (apiClient.isFetchConfigurationFailed()) {
       state = AgStateMachineSensorConfigFailed;
       if (apiClient.isNotAvailableOnDashboard()) {
         stateMachine.displaySetAddToDashBoard();

--- a/examples/DiyProIndoorV3_3/DiyProIndoorV3_3.ino
+++ b/examples/DiyProIndoorV3_3/DiyProIndoorV3_3.ino
@@ -149,7 +149,10 @@ void setup() {
         initMqtt();
         sendDataToAg();
 
-        apiClient.fetchServerConfiguration();
+        if (configuration.getConfigurationControl() !=
+            ConfigurationControl::ConfigurationControlLocal) {
+          apiClient.fetchServerConfiguration();
+        }
         configSchedule.update();
         if (apiClient.isFetchConfigureFailed()) {
           if (apiClient.isNotAvailableOnDashboard()) {
@@ -467,6 +470,14 @@ static void failedHandler(String msg) {
 }
 
 static void configurationUpdateSchedule(void) {
+  if (configuration.isOfflineMode() ||
+      configuration.getConfigurationControl() == ConfigurationControl::ConfigurationControlLocal) {
+    Serial.println("Ignore fetch server configuration. Either mode is offline "
+                   "or configurationControl set to local");
+    apiClient.resetFetchConfigureState();
+    return;
+  }
+
   if (apiClient.fetchServerConfiguration()) {
     configUpdateHandle();
   }
@@ -573,17 +584,21 @@ static void sendDataToServer(void) {
   int bootCount = measurements.bootCount() + 1;
   measurements.setBootCount(bootCount);
 
-  /** Ignore send data to server if postToAirGradient disabled */
-  if (configuration.isPostDataToAirGradient() == false ||
-      configuration.isOfflineMode()) {
+  if (configuration.isOfflineMode() || !configuration.isPostDataToAirGradient()) {
+    Serial.println("Ignore send data to server. Either mode is offline "
+                   "or post data to server disabled");
+    return;
+  }
+
+  if (wifiConnector.isConnected() == false) {
+    Serial.println("WiFi not connected, skip post data to server");
     return;
   }
 
   String syncData = measurements.toString(false, fwMode, wifiConnector.RSSI(), ag, configuration);
   if (apiClient.postToServer(syncData)) {
     Serial.println();
-    Serial.println(
-        "Online mode and isPostToAirGradient = true: watchdog reset");
+    Serial.println("Online mode and isPostToAirGradient = true");
     Serial.println();
   }
 }

--- a/examples/DiyProIndoorV3_3/DiyProIndoorV3_3.ino
+++ b/examples/DiyProIndoorV3_3/DiyProIndoorV3_3.ino
@@ -585,7 +585,7 @@ static void sendDataToServer(void) {
   measurements.setBootCount(bootCount);
 
   if (configuration.isOfflineMode() || !configuration.isPostDataToAirGradient()) {
-    Serial.println("Ignore send data to server. Either mode is offline "
+    Serial.println("Skipping transmission of data to AG server. Either mode is offline "
                    "or post data to server disabled");
     return;
   }

--- a/examples/DiyProIndoorV3_3/OpenMetrics.cpp
+++ b/examples/DiyProIndoorV3_3/OpenMetrics.cpp
@@ -43,7 +43,7 @@ String OpenMetrics::getPayload(void) {
              "1 if the AirGradient device was able to successfully fetch its "
              "configuration from the server",
              "gauge");
-  add_metric_point("", apiClient.isFetchConfigureFailed() ? "0" : "1");
+  add_metric_point("", apiClient.isFetchConfigurationFailed() ? "0" : "1");
 
   add_metric(
       "post_ok",

--- a/examples/DiyProIndoorV4_2/DiyProIndoorV4_2.ino
+++ b/examples/DiyProIndoorV4_2/DiyProIndoorV4_2.ino
@@ -176,7 +176,10 @@ void setup() {
         initMqtt();
         sendDataToAg();
 
-        apiClient.fetchServerConfiguration();
+        if (configuration.getConfigurationControl() !=
+            ConfigurationControl::ConfigurationControlLocal) {
+          apiClient.fetchServerConfiguration();
+        }
         configSchedule.update();
         if (apiClient.isFetchConfigureFailed()) {
           if (apiClient.isNotAvailableOnDashboard()) {
@@ -507,6 +510,14 @@ static void failedHandler(String msg) {
 }
 
 static void configurationUpdateSchedule(void) {
+  if (configuration.isOfflineMode() ||
+      configuration.getConfigurationControl() == ConfigurationControl::ConfigurationControlLocal) {
+    Serial.println("Ignore fetch server configuration. Either mode is offline "
+                   "or configurationControl set to local");
+    apiClient.resetFetchConfigureState();
+    return;
+  }
+
   if (apiClient.fetchServerConfiguration()) {
     configUpdateHandle();
   }
@@ -614,17 +625,21 @@ static void sendDataToServer(void) {
   int bootCount = measurements.bootCount() + 1;
   measurements.setBootCount(bootCount);
 
-  /** Ignore send data to server if postToAirGradient disabled */
-  if (configuration.isPostDataToAirGradient() == false ||
-      configuration.isOfflineMode()) {
+  if (configuration.isOfflineMode() || !configuration.isPostDataToAirGradient()) {
+    Serial.println("Ignore send data to server. Either mode is offline "
+                   "or post data to server disabled");
+    return;
+  }
+
+  if (wifiConnector.isConnected() == false) {
+    Serial.println("WiFi not connected, skip post data to server");
     return;
   }
 
   String syncData = measurements.toString(false, fwMode, wifiConnector.RSSI(), ag, configuration);
   if (apiClient.postToServer(syncData)) {
     Serial.println();
-    Serial.println(
-        "Online mode and isPostToAirGradient = true: watchdog reset");
+    Serial.println("Online mode and isPostToAirGradient = true");
     Serial.println();
   }
 }

--- a/examples/DiyProIndoorV4_2/DiyProIndoorV4_2.ino
+++ b/examples/DiyProIndoorV4_2/DiyProIndoorV4_2.ino
@@ -626,7 +626,7 @@ static void sendDataToServer(void) {
   measurements.setBootCount(bootCount);
 
   if (configuration.isOfflineMode() || !configuration.isPostDataToAirGradient()) {
-    Serial.println("Ignore send data to server. Either mode is offline "
+    Serial.println("Skipping transmission of data to AG server. Either mode is offline "
                    "or post data to server disabled");
     return;
   }

--- a/examples/DiyProIndoorV4_2/DiyProIndoorV4_2.ino
+++ b/examples/DiyProIndoorV4_2/DiyProIndoorV4_2.ino
@@ -632,7 +632,7 @@ static void sendDataToServer(void) {
   }
 
   if (wifiConnector.isConnected() == false) {
-    Serial.println("WiFi not connected, skip post data to server");
+    Serial.println("WiFi not connected, skipping data transmission to AG server");
     return;
   }
 

--- a/examples/DiyProIndoorV4_2/DiyProIndoorV4_2.ino
+++ b/examples/DiyProIndoorV4_2/DiyProIndoorV4_2.ino
@@ -181,7 +181,7 @@ void setup() {
           apiClient.fetchServerConfiguration();
         }
         configSchedule.update();
-        if (apiClient.isFetchConfigureFailed()) {
+        if (apiClient.isFetchConfigurationFailed()) {
           if (apiClient.isNotAvailableOnDashboard()) {
             stateMachine.displaySetAddToDashBoard();
             stateMachine.displayHandle(
@@ -514,7 +514,7 @@ static void configurationUpdateSchedule(void) {
       configuration.getConfigurationControl() == ConfigurationControl::ConfigurationControlLocal) {
     Serial.println("Ignore fetch server configuration. Either mode is offline "
                    "or configurationControl set to local");
-    apiClient.resetFetchConfigureState();
+    apiClient.resetFetchConfigurationStatus();
     return;
   }
 
@@ -575,7 +575,7 @@ static void appDispHandler(void) {
   if (configuration.isOfflineMode() == false) {
     if (wifiConnector.isConnected() == false) {
       state = AgStateMachineWiFiLost;
-    } else if (apiClient.isFetchConfigureFailed()) {
+    } else if (apiClient.isFetchConfigurationFailed()) {
       state = AgStateMachineSensorConfigFailed;
       if (apiClient.isNotAvailableOnDashboard()) {
         stateMachine.displaySetAddToDashBoard();

--- a/examples/DiyProIndoorV4_2/OpenMetrics.cpp
+++ b/examples/DiyProIndoorV4_2/OpenMetrics.cpp
@@ -43,7 +43,7 @@ String OpenMetrics::getPayload(void) {
              "1 if the AirGradient device was able to successfully fetch its "
              "configuration from the server",
              "gauge");
-  add_metric_point("", apiClient.isFetchConfigureFailed() ? "0" : "1");
+  add_metric_point("", apiClient.isFetchConfigurationFailed() ? "0" : "1");
 
   add_metric(
       "post_ok",

--- a/examples/OneOpenAir/OneOpenAir.ino
+++ b/examples/OneOpenAir/OneOpenAir.ino
@@ -861,7 +861,7 @@ void initiateNetwork() {
   // Initiate local network configuration
   mdnsInit();
   localServer.begin();
-  // Apply mqtt connection
+  // Apply mqtt connection if configured
   initMqtt();
 
   // Ignore the rest if cloud connection to AirGradient is disabled
@@ -869,7 +869,10 @@ void initiateNetwork() {
     return;
   }
 
-  // Send ping to aigradient server
+  // Initialize api client
+  apiClient.begin();
+
+  // Send ping to airgradient server
   sendDataToAg();
 
 // OTA check

--- a/examples/OneOpenAir/OneOpenAir.ino
+++ b/examples/OneOpenAir/OneOpenAir.ino
@@ -1194,7 +1194,7 @@ static void sendDataToServer(void) {
   }
 
   if (wifiConnector.isConnected() == false) {
-    Serial.println("WiFi not connected, skip post data to server");
+    Serial.println("WiFi not connected, skipping data transmission to AG server");
     return;
   }
 

--- a/examples/OneOpenAir/OneOpenAir.ino
+++ b/examples/OneOpenAir/OneOpenAir.ino
@@ -870,7 +870,7 @@ void initializeNetwork() {
   // Initialize api client
   apiClient.begin();
 
-  // Send data for the first time to airgradient at boot 
+  // Send data for the first time to AG server at boot 
   sendDataToAg();
 
 // OTA check

--- a/examples/OneOpenAir/OneOpenAir.ino
+++ b/examples/OneOpenAir/OneOpenAir.ino
@@ -112,7 +112,7 @@ static void factoryConfigReset(void);
 static void wdgFeedUpdate(void);
 static void ledBarEnabledUpdate(void);
 static bool sgp41Init(void);
-static void firmwareCheckForUpdate(void);
+static void checkForFirmwareUpdate(void);
 static void otaHandlerCallback(OtaHandler::OtaState state, String mesasge);
 static void displayExecuteOta(OtaHandler::OtaState state, String msg, int processing);
 static int calculateMaxPeriod(int updateInterval);
@@ -127,7 +127,7 @@ AgSchedule pmsSchedule(SENSOR_PM_UPDATE_INTERVAL, updatePm);
 AgSchedule tempHumSchedule(SENSOR_TEMP_HUM_UPDATE_INTERVAL, tempHumUpdate);
 AgSchedule tvocSchedule(SENSOR_TVOC_UPDATE_INTERVAL, updateTvoc);
 AgSchedule watchdogFeedSchedule(60000, wdgFeedUpdate);
-AgSchedule checkForUpdateSchedule(FIRMWARE_CHECK_FOR_UPDATE_MS, firmwareCheckForUpdate);
+AgSchedule checkForUpdateSchedule(FIRMWARE_CHECK_FOR_UPDATE_MS, checkForFirmwareUpdate);
 
 void setup() {
   /** Serial for print debug message */
@@ -877,7 +877,7 @@ void initializeNetwork() {
 #ifdef ESP8266
 // ota not supported
 #else
-  firmwareCheckForUpdate();
+  checkForFirmwareUpdate();
   checkForUpdateSchedule.update();
 #endif
 

--- a/examples/OneOpenAir/OneOpenAir.ino
+++ b/examples/OneOpenAir/OneOpenAir.ino
@@ -884,7 +884,7 @@ void initializeNetwork() {
 
   apiClient.fetchServerConfiguration();
   configSchedule.update();
-  if (apiClient.isFetchConfigureFailed()) {
+  if (apiClient.isFetchConfigurationFailed()) {
     if (ag->isOne()) {
       if (apiClient.isNotAvailableOnDashboard()) {
         stateMachine.displaySetAddToDashBoard();
@@ -905,7 +905,7 @@ static void configurationUpdateSchedule(void) {
       configuration.getConfigurationControl() == ConfigurationControl::ConfigurationControlLocal) {
     Serial.println("Ignore fetch server configuration. Either mode is offline or cloud connection "
                    "disabled or configurationControl set to local");
-    apiClient.resetFetchConfigureState();
+    apiClient.resetFetchConfigurationStatus();
     return;
   }
 
@@ -1019,7 +1019,7 @@ static void updateDisplayAndLedBar(void) {
   }
 
   AgStateMachineState state = AgStateMachineNormal;
-  if (apiClient.isFetchConfigureFailed()) {
+  if (apiClient.isFetchConfigurationFailed()) {
     state = AgStateMachineSensorConfigFailed;
     if (apiClient.isNotAvailableOnDashboard()) {
       stateMachine.displaySetAddToDashBoard();

--- a/examples/OneOpenAir/OneOpenAir.ino
+++ b/examples/OneOpenAir/OneOpenAir.ino
@@ -464,9 +464,9 @@ static bool sgp41Init(void) {
   return false;
 }
 
-static void firmwareCheckForUpdate(void) {
+static void checkForFirmwareUpdate(void) {
   Serial.println();
-  Serial.print("firmwareCheckForUpdate: ");
+  Serial.print("checkForFirmwareUpdate: ");
 
   if (configuration.isOfflineMode() || configuration.isCloudConnectionDisabled()) {
     Serial.println("mode is offline or cloud connection disabled, ignored");
@@ -870,7 +870,7 @@ void initializeNetwork() {
   // Initialize api client
   apiClient.begin();
 
-  // Check and process if AirGradient server is reachable
+  // Send data for the first time to airgradient at boot 
   sendDataToAg();
 
 // OTA check
@@ -1188,7 +1188,7 @@ static void sendDataToServer(void) {
 
   if (configuration.isOfflineMode() || configuration.isCloudConnectionDisabled() ||
       !configuration.isPostDataToAirGradient()) {
-    Serial.println("Ignore send data to server. Either mode is offline or cloud connection is "
+    Serial.println("Skipping transmission of data to AG server. Either mode is offline or cloud connection is "
                    "disabled or post data to server disabled");
     return;
   }

--- a/examples/OneOpenAir/OneOpenAir.ino
+++ b/examples/OneOpenAir/OneOpenAir.ino
@@ -96,7 +96,7 @@ static bool ledBarButtonTest = false;
 static String fwNewVersion;
 
 static void boardInit(void);
-static void initiateNetwork(void);
+static void initializeNetwork(void);
 static void failedHandler(String msg);
 static void configurationUpdateSchedule(void);
 static void updateDisplayAndLedBar(void);
@@ -209,9 +209,9 @@ void setup() {
     connectToWifi = true;
   }
 
-  // Initiate networking configuration
+  // Initialize networking configuration
   if (connectToWifi) {
-    initiateNetwork();
+    initializeNetwork();
   }
 
   /** Set offline mode without saving, cause wifi is not configured */
@@ -838,8 +838,7 @@ static void failedHandler(String msg) {
   }
 }
 
-void initiateNetwork() {
-
+void initializeNetwork() {
   if (!wifiConnector.connect()) {
     Serial.println("Cannot initiate wifi connection");
     return;

--- a/examples/OneOpenAir/OneOpenAir.ino
+++ b/examples/OneOpenAir/OneOpenAir.ino
@@ -872,7 +872,7 @@ void initiateNetwork() {
   // Initialize api client
   apiClient.begin();
 
-  // Send ping to airgradient server
+  // Check and process if AirGradient server is reachable
   sendDataToAg();
 
 // OTA check

--- a/examples/OneOpenAir/OpenMetrics.cpp
+++ b/examples/OneOpenAir/OpenMetrics.cpp
@@ -43,7 +43,7 @@ String OpenMetrics::getPayload(void) {
              "1 if the AirGradient device was able to successfully fetch its "
              "configuration from the server",
              "gauge");
-  add_metric_point("", apiClient.isFetchConfigureFailed() ? "0" : "1");
+  add_metric_point("", apiClient.isFetchConfigurationFailed() ? "0" : "1");
 
   add_metric(
       "post_ok",

--- a/src/AgApiClient.cpp
+++ b/src/AgApiClient.cpp
@@ -153,12 +153,12 @@ bool AgApiClient::postToServer(String data) {
  * @return true Success
  * @return false Failure
  */
-bool AgApiClient::isFetchConfigureFailed(void) { return getConfigFailed; }
+bool AgApiClient::isFetchConfigurationFailed(void) { return getConfigFailed; }
 
 /**
- * @brief Reset getConfigFailed state to false
+ * @brief Reset status of get configuration from AirGradient cloud
  */
-void AgApiClient::resetFetchConfigureState(void) { getConfigFailed = false; }
+void AgApiClient::resetFetchConfigurationStatus(void) { getConfigFailed = false; }
 
 /**
  * @brief Get failed status when post data to AirGradient cloud

--- a/src/AgApiClient.cpp
+++ b/src/AgApiClient.cpp
@@ -34,17 +34,6 @@ void AgApiClient::begin(void) {
  * @return false Failure
  */
 bool AgApiClient::fetchServerConfiguration(void) {
-  if (config.getConfigurationControl() ==
-          ConfigurationControl::ConfigurationControlLocal ||
-      config.isOfflineMode()) {
-    logWarning("Ignore fetch server configuration");
-
-    // Clear server configuration failed flag, cause it's ignore but not
-    // really failed
-    getConfigFailed = false;
-    return false;
-  }
-
   String uri = apiRoot + "/sensors/airgradient:" +
                ag->deviceId() + "/one/config";
 
@@ -114,15 +103,6 @@ bool AgApiClient::fetchServerConfiguration(void) {
  * @return false Failure
  */
 bool AgApiClient::postToServer(String data) {
-  if (config.isPostDataToAirGradient() == false) {
-    logWarning("Ignore post data to server");
-    return true;
-  }
-
-  if (WiFi.isConnected() == false) {
-    return false;
-  }
-
   String uri = apiRoot + "/sensors/airgradient:" + ag->deviceId() + "/measures";
 #ifdef ESP8266
   HTTPClient client;
@@ -174,6 +154,11 @@ bool AgApiClient::postToServer(String data) {
  * @return false Failure
  */
 bool AgApiClient::isFetchConfigureFailed(void) { return getConfigFailed; }
+
+/**
+ * @brief Reset getConfigFailed state to false
+ */
+void AgApiClient::resetFetchConfigureState(void) { getConfigFailed = false; }
 
 /**
  * @brief Get failed status when post data to AirGradient cloud

--- a/src/AgApiClient.h
+++ b/src/AgApiClient.h
@@ -40,8 +40,8 @@ public:
   void begin(void);
   bool fetchServerConfiguration(void);
   bool postToServer(String data);
-  bool isFetchConfigureFailed(void);
-  void resetFetchConfigureState(void);
+  bool isFetchConfigurationFailed(void);
+  void resetFetchConfigurationStatus(void);
   bool isPostToServerFailed(void);
   bool isNotAvailableOnDashboard(void);
   void setAirGradient(AirGradient *ag);

--- a/src/AgApiClient.h
+++ b/src/AgApiClient.h
@@ -41,6 +41,7 @@ public:
   bool fetchServerConfiguration(void);
   bool postToServer(String data);
   bool isFetchConfigureFailed(void);
+  void resetFetchConfigureState(void);
   bool isPostToServerFailed(void);
   bool isNotAvailableOnDashboard(void);
   void setAirGradient(AirGradient *ag);

--- a/src/AgConfigure.cpp
+++ b/src/AgConfigure.cpp
@@ -1039,20 +1039,20 @@ void Configuration::toConfig(const char *buf) {
   }
 
   bool changed = false;
-  bool isInvalid = false;
+  bool isConfigFieldInvalid = false;
 
   /** Validate country */
   if (JSON.typeof_(jconfig[jprop_country]) != "string") {
-    isInvalid = true;
+    isConfigFieldInvalid = true;
   } else {
     String country = jconfig[jprop_country];
     if (country.length() != 2) {
-      isInvalid = true;
+      isConfigFieldInvalid = true;
     } else {
-      isInvalid = false;
+      isConfigFieldInvalid = false;
     }
   }
-  if (isInvalid) {
+  if (isConfigFieldInvalid) {
     jconfig[jprop_country] = jprop_country_default;
     changed = true;
     logInfo("toConfig: country changed");
@@ -1060,17 +1060,17 @@ void Configuration::toConfig(const char *buf) {
 
   /** validate: PM standard */
   if (JSON.typeof_(jconfig[jprop_pmStandard]) != "string") {
-    isInvalid = true;
+    isConfigFieldInvalid = true;
   } else {
     String standard = jconfig[jprop_pmStandard];
     if (standard != getPMStandardString(true) &&
         standard != getPMStandardString(false)) {
-      isInvalid = true;
+      isConfigFieldInvalid = true;
     } else {
-      isInvalid = false;
+      isConfigFieldInvalid = false;
     }
   }
-  if (isInvalid) {
+  if (isConfigFieldInvalid) {
     jconfig[jprop_pmStandard] = jprop_pmStandard_default;
     changed = true;
     logInfo("toConfig: pmStandard changed");
@@ -1078,18 +1078,18 @@ void Configuration::toConfig(const char *buf) {
 
   /** validate led bar mode */
   if (JSON.typeof_(jconfig[jprop_ledBarMode]) != "string") {
-    isInvalid = true;
+    isConfigFieldInvalid = true;
   } else {
     String mode = jconfig[jprop_ledBarMode];
     if (mode != getLedBarModeName(LedBarMode::LedBarModeCO2) &&
         mode != getLedBarModeName(LedBarMode::LedBarModeOff) &&
         mode != getLedBarModeName(LedBarMode::LedBarModePm)) {
-      isInvalid = true;
+      isConfigFieldInvalid = true;
     } else {
-      isInvalid = false;
+      isConfigFieldInvalid = false;
     }
   }
-  if (isInvalid) {
+  if (isConfigFieldInvalid) {
     jconfig[jprop_ledBarMode] = jprop_ledBarMode_default;
     changed = true;
     logInfo("toConfig: ledBarMode changed");
@@ -1097,11 +1097,11 @@ void Configuration::toConfig(const char *buf) {
 
   /** validate abcday */
   if (JSON.typeof_(jconfig[jprop_abcDays]) != "number") {
-    isInvalid = true;
+    isConfigFieldInvalid = true;
   } else {
-    isInvalid = false;
+    isConfigFieldInvalid = false;
   }
-  if (isInvalid) {
+  if (isConfigFieldInvalid) {
     jconfig[jprop_abcDays] = jprop_abcDays_default;
     changed = true;
     logInfo("toConfig: abcDays changed");
@@ -1109,16 +1109,16 @@ void Configuration::toConfig(const char *buf) {
 
   /** validate tvoc learning offset */
   if (JSON.typeof_(jconfig[jprop_tvocLearningOffset]) != "number") {
-    isInvalid = true;
+    isConfigFieldInvalid = true;
   } else {
     int value = jconfig[jprop_tvocLearningOffset];
     if (value < 0) {
-      isInvalid = true;
+      isConfigFieldInvalid = true;
     } else {
-      isInvalid = false;
+      isConfigFieldInvalid = false;
     }
   }
-  if (isInvalid) {
+  if (isConfigFieldInvalid) {
     jconfig[jprop_tvocLearningOffset] = jprop_tvocLearningOffset_default;
     changed = true;
     logInfo("toConfig: tvocLearningOffset changed");
@@ -1126,16 +1126,16 @@ void Configuration::toConfig(const char *buf) {
 
   /** validate nox learning offset */
   if (JSON.typeof_(jconfig[jprop_noxLearningOffset]) != "number") {
-    isInvalid = true;
+    isConfigFieldInvalid = true;
   } else {
     int value = jconfig[jprop_noxLearningOffset];
     if (value < 0) {
-      isInvalid = true;
+      isConfigFieldInvalid = true;
     } else {
-      isInvalid = false;
+      isConfigFieldInvalid = false;
     }
   }
-  if (isInvalid) {
+  if (isConfigFieldInvalid) {
     jconfig[jprop_noxLearningOffset] = jprop_noxLearningOffset_default;
     changed = true;
     logInfo("toConfig: noxLearningOffset changed");
@@ -1143,11 +1143,11 @@ void Configuration::toConfig(const char *buf) {
 
   /** validate mqtt broker */
   if (JSON.typeof_(jconfig[jprop_mqttBrokerUrl]) != "string") {
-    isInvalid = true;
+    isConfigFieldInvalid = true;
   } else {
-    isInvalid = false;
+    isConfigFieldInvalid = false;
   }
-  if (isInvalid) {
+  if (isConfigFieldInvalid) {
     changed = true;
     jconfig[jprop_mqttBrokerUrl] = jprop_mqttBrokerUrl_default;
     logInfo("toConfig: mqttBroker changed");
@@ -1155,16 +1155,16 @@ void Configuration::toConfig(const char *buf) {
 
   /** Validate temperature unit */
   if (JSON.typeof_(jconfig[jprop_temperatureUnit]) != "string") {
-    isInvalid = true;
+    isConfigFieldInvalid = true;
   } else {
     String unit = jconfig[jprop_temperatureUnit];
     if (unit != "c" && unit != "f") {
-      isInvalid = true;
+      isConfigFieldInvalid = true;
     } else {
-      isInvalid = false;
+      isConfigFieldInvalid = false;
     }
   }
-  if (isInvalid) {
+  if (isConfigFieldInvalid) {
     jconfig[jprop_temperatureUnit] = jprop_temperatureUnit_default;
     changed = true;
     logInfo("toConfig: temperatureUnit changed");
@@ -1172,11 +1172,11 @@ void Configuration::toConfig(const char *buf) {
 
   /** validate disableCloudConnection configuration */
   if (JSON.typeof_(jconfig[jprop_disableCloudConnection]) != "boolean") {
-    isInvalid = true;
+    isConfigFieldInvalid = true;
   } else {
-    isInvalid = false;
+    isConfigFieldInvalid = false;
   }
-  if (isInvalid) {
+  if (isConfigFieldInvalid) {
     jconfig[jprop_disableCloudConnection] = jprop_disableCloudConnection_default;
     changed = true;
     logInfo("toConfig: disableCloudConnection changed");
@@ -1184,7 +1184,7 @@ void Configuration::toConfig(const char *buf) {
 
   /** validate configuration control */
   if (JSON.typeof_(jprop_configurationControl) != "string") {
-    isInvalid = true;
+    isConfigFieldInvalid = true;
   } else {
     String ctrl = jconfig[jprop_configurationControl];
     if (ctrl != String(CONFIGURATION_CONTROL_NAME
@@ -1193,12 +1193,12 @@ void Configuration::toConfig(const char *buf) {
                            [ConfigurationControl::ConfigurationControlLocal]) &&
         ctrl != String(CONFIGURATION_CONTROL_NAME
                            [ConfigurationControl::ConfigurationControlCloud])) {
-      isInvalid = true;
+      isConfigFieldInvalid = true;
     } else {
-      isInvalid = false;
+      isConfigFieldInvalid = false;
     }
   }
-  if (isInvalid) {
+  if (isConfigFieldInvalid) {
     jconfig[jprop_configurationControl] =jprop_configurationControl_default;
     changed = true;
     logInfo("toConfig: configurationControl changed");
@@ -1206,11 +1206,11 @@ void Configuration::toConfig(const char *buf) {
 
   /** Validate post to airgradient cloud */
   if (JSON.typeof_(jconfig[jprop_postDataToAirGradient]) != "boolean") {
-    isInvalid = true;
+    isConfigFieldInvalid = true;
   } else {
-    isInvalid = false;
+    isConfigFieldInvalid = false;
   }
-  if (isInvalid) {
+  if (isConfigFieldInvalid) {
     jconfig[jprop_postDataToAirGradient] = jprop_postDataToAirGradient_default;
     changed = true;
     logInfo("toConfig: postToAirGradient changed");
@@ -1218,16 +1218,16 @@ void Configuration::toConfig(const char *buf) {
 
   /** validate led bar brightness */
   if (JSON.typeof_(jconfig[jprop_ledBarBrightness]) != "number") {
-    isInvalid = true;
+    isConfigFieldInvalid = true;
   } else {
     int value = jconfig[jprop_ledBarBrightness];
     if (value < 0 || value > 100) {
-      isInvalid = true;
+      isConfigFieldInvalid = true;
     } else {
-      isInvalid = false;
+      isConfigFieldInvalid = false;
     }
   }
-  if (isInvalid) {
+  if (isConfigFieldInvalid) {
     jconfig[jprop_ledBarBrightness] = jprop_ledBarBrightness_default;
     changed = true;
     logInfo("toConfig: ledBarBrightness changed");
@@ -1235,16 +1235,16 @@ void Configuration::toConfig(const char *buf) {
 
   /** Validate display brightness */
   if (JSON.typeof_(jconfig[jprop_displayBrightness]) != "number") {
-    isInvalid = true;
+    isConfigFieldInvalid = true;
   } else {
     int value = jconfig[jprop_displayBrightness];
     if (value < 0 || value > 100) {
-      isInvalid = true;
+      isConfigFieldInvalid = true;
     } else {
-      isInvalid = false;
+      isConfigFieldInvalid = false;
     }
   }
-  if (isInvalid) {
+  if (isConfigFieldInvalid) {
     jconfig[jprop_displayBrightness] = jprop_displayBrightness_default;
     changed = true;
     logInfo("toConfig: displayBrightness changed");

--- a/src/AgConfigure.cpp
+++ b/src/AgConfigure.cpp
@@ -47,6 +47,7 @@ JSON_PROP_DEF(mqttBrokerUrl);
 JSON_PROP_DEF(temperatureUnit);
 JSON_PROP_DEF(configurationControl);
 JSON_PROP_DEF(postDataToAirGradient);
+JSON_PROP_DEF(disableCloudConnection);
 JSON_PROP_DEF(ledBarBrightness);
 JSON_PROP_DEF(displayBrightness);
 JSON_PROP_DEF(co2CalibrationRequested);
@@ -66,6 +67,7 @@ JSON_PROP_DEF(corrections);
 #define jprop_temperatureUnit_default                 "c"
 #define jprop_configurationControl_default            String(CONFIGURATION_CONTROL_NAME[ConfigurationControl::ConfigurationControlBoth])
 #define jprop_postDataToAirGradient_default           true
+#define jprop_disableCloudConnection_default          false
 #define jprop_ledBarBrightness_default                100
 #define jprop_displayBrightness_default               100
 #define jprop_offlineMode_default                     false
@@ -272,6 +274,7 @@ void Configuration::defaultConfig(void) {
   jconfig[jprop_configurationControl] = jprop_configurationControl_default;
   jconfig[jprop_pmStandard] = jprop_pmStandard_default;
   jconfig[jprop_temperatureUnit] = jprop_temperatureUnit_default;
+  jconfig[jprop_disableCloudConnection] = jprop_disableCloudConnection_default;
   jconfig[jprop_postDataToAirGradient] = jprop_postDataToAirGradient_default;
   if (ag->isOne()) {
     jconfig[jprop_ledBarBrightness] = jprop_ledBarBrightness_default;
@@ -1167,6 +1170,18 @@ void Configuration::toConfig(const char *buf) {
     logInfo("toConfig: temperatureUnit changed");
   }
 
+  /** validate disableCloudConnection configuration */
+  if (JSON.typeof_(jconfig[jprop_disableCloudConnection]) != "boolean") {
+    isInvalid = true;
+  } else {
+    isInvalid = false;
+  }
+  if (isInvalid) {
+    jconfig[jprop_disableCloudConnection] = jprop_disableCloudConnection_default;
+    changed = true;
+    logInfo("toConfig: disableCloudConnection changed");
+  }
+
   /** validate configuration control */
   if (JSON.typeof_(jprop_configurationControl) != "string") {
     isInvalid = true;
@@ -1332,6 +1347,17 @@ void Configuration::setOfflineMode(bool offline) {
 
 void Configuration::setOfflineModeWithoutSave(bool offline) {
   _offlineMode = offline;
+}
+
+bool Configuration::isCloudConnectionDisabled(void) {
+  bool disabled = jconfig[jprop_disableCloudConnection];
+  return disabled;
+}
+
+void Configuration::setDisableCloudConnection(bool disable) {
+  logInfo("Set DisableCloudConnection to " + String(disable ? "True" : "False"));
+  jconfig[jprop_disableCloudConnection] = disable;
+  saveConfig();
 }
 
 bool Configuration::isLedBarModeChanged(void) { 

--- a/src/AgConfigure.h
+++ b/src/AgConfigure.h
@@ -94,6 +94,8 @@ public:
   bool isOfflineMode(void);
   void setOfflineMode(bool offline);
   void setOfflineModeWithoutSave(bool offline);
+  bool isCloudConnectionDisabled(void);
+  void setDisableCloudConnection(bool disable);
   bool isLedBarModeChanged(void);
   bool isMonitorDisplayCompensatedValues(void);
   bool isPMCorrectionChanged(void);

--- a/src/AgWiFiConnector.cpp
+++ b/src/AgWiFiConnector.cpp
@@ -87,8 +87,8 @@ bool WifiConnector::connect(void) {
   WiFiManagerParameter disableCloudInfo(
       "<p>Prevent connection to the AirGradient Server. Important: Only enable "
       "it if you are sure you don't want to use any AirGradient cloud "
-      "features. As a result you will not receive automatic firmware updates "
-      "configure from cloud and your data will not reach the AirGradient dashboard.</p>");
+      "features. As a result you will not receive automatic firmware updates, "
+      "configuration settings from cloud and the measure data will not reach the AirGradient dashboard.</p>");
   WIFI()->addParameter(&disableCloudInfo);
 
   WIFI()->autoConnect(ssid.c_str(), WIFI_HOTSPOT_PASSWORD_DEFAULT);

--- a/src/AgWiFiConnector.cpp
+++ b/src/AgWiFiConnector.cpp
@@ -81,16 +81,15 @@ bool WifiConnector::connect(void) {
   // ssid = "AG-" + String(ESP.getChipId(), HEX);
   WIFI()->setConfigPortalTimeout(WIFI_CONNECT_COUNTDOWN_MAX);
 
-  WiFiManagerParameter postToAg("chbPostToAg",
-                                "Prevent Connection to AirGradient Server", "T",
-                                2, "type=\"checkbox\" ", WFM_LABEL_AFTER);
-  WIFI()->addParameter(&postToAg);
-  WiFiManagerParameter postToAgInfo(
+  WiFiManagerParameter disableCloud("chbPostToAg", "Prevent Connection to AirGradient Server", "T",
+                                    2, "type=\"checkbox\" ", WFM_LABEL_AFTER);
+  WIFI()->addParameter(&disableCloud);
+  WiFiManagerParameter disableCloudInfo(
       "<p>Prevent connection to the AirGradient Server. Important: Only enable "
       "it if you are sure you don't want to use any AirGradient cloud "
       "features. As a result you will not receive automatic firmware updates "
       "and your data will not reach the AirGradient dashboard.</p>");
-  WIFI()->addParameter(&postToAgInfo);
+  WIFI()->addParameter(&disableCloudInfo);
 
   WIFI()->autoConnect(ssid.c_str(), WIFI_HOTSPOT_PASSWORD_DEFAULT);
 
@@ -174,12 +173,11 @@ bool WifiConnector::connect(void) {
     logInfo("WiFi Connected: " + WiFi.SSID() + " IP: " + localIpStr());
 
     if (hasPortalConfig) {
-      String result = String(postToAg.getValue());
-      logInfo("Setting postToAirGradient set from " +
-              String(config.isPostDataToAirGradient() ? "True" : "False") +
-              String(" to ") + String(result != "T" ? "True" : "False") +
-              String(" successful"));
-      config.setPostToAirGradient(result != "T");
+      String result = String(disableCloud.getValue());
+      logInfo("Setting disableCloudConnection set from " +
+              String(config.isCloudConnectionDisabled() ? "True" : "False") + String(" to ") +
+              String(result == "T" ? "True" : "False") + String(" successful"));
+      config.setDisableCloudConnection(result == "T");
     }
     hasPortalConfig = false;
   }

--- a/src/AgWiFiConnector.cpp
+++ b/src/AgWiFiConnector.cpp
@@ -88,7 +88,7 @@ bool WifiConnector::connect(void) {
       "<p>Prevent connection to the AirGradient Server. Important: Only enable "
       "it if you are sure you don't want to use any AirGradient cloud "
       "features. As a result you will not receive automatic firmware updates "
-      "and your data will not reach the AirGradient dashboard.</p>");
+      "configure from cloud and your data will not reach the AirGradient dashboard.</p>");
   WIFI()->addParameter(&disableCloudInfo);
 
   WIFI()->autoConnect(ssid.c_str(), WIFI_HOTSPOT_PASSWORD_DEFAULT);


### PR DESCRIPTION
## Changes

1. `disableCloudConnection` config added to disable every cloud connection to airgradient server
2. `disableCloudConnection` not applied for DIY model
3. `local-server.md` updated, describing `offlineMode` and `disableCloudConnection`
4. Adding more verbose logs regarding ignored connection to airgradient server

```
> Ignore fetch server configuration. Either mode is offline or cloud connection disabled or configurationControl set to local
> Ignore send data to server. Either mode is offline or cloud connection is disabled or post data to server disabled
> firmwareCheckForUpdate: mode is offline or cloud connection disabled, ignored
```