### PR TITLE
Update workflow to use compile-sketches action

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -22,7 +22,7 @@ jobs:
             core_url: "https://arduino.esp8266.com/stable/package_esp8266com_index.json"
           - fqbn: "esp32:esp32:esp32c3"
             core: "esp32:esp32"
-            core_version: "2.0.11"
+            core_version: "2.0.17"
             core_url: "https://espressif.github.io/arduino-esp32/package_esp32_index.json"
             board_options: "JTAGAdapter=default,CDCOnBoot=cdc,PartitionScheme=min_spiffs,CPUFreq=160,FlashMode=qio,FlashFreq=80,FlashSize=4M,UploadSpeed=921600,DebugLevel=verbose,EraseFlash=none"
         exclude:
@@ -34,7 +34,7 @@ jobs:
             fqbn: "esp32:esp32:esp32c3"
           - example: "OneOpenAir"
             fqbn: "esp8266:esp8266:d1_mini"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4.2.2
       - uses: arduino/compile-sketches@v1.1.2

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -17,11 +17,14 @@ jobs:
           - "esp32:esp32:esp32c3"
         include:
           - fqbn: "esp8266:esp8266:d1_mini"
-            core: "esp8266:esp8266@3.1.2"
+            core: "esp8266:esp8266"
+            core_version: "3.1.2"
             core_url: "https://arduino.esp8266.com/stable/package_esp8266com_index.json"
           - fqbn: "esp32:esp32:esp32c3"
+            core: "esp32:esp32"
+            core_version: "2.0.11"
+            core_url: "https://espressif.github.io/arduino-esp32/package_esp32_index.json"
             board_options: "JTAGAdapter=default,CDCOnBoot=cdc,PartitionScheme=min_spiffs,CPUFreq=160,FlashMode=qio,FlashFreq=80,FlashSize=4M,UploadSpeed=921600,DebugLevel=verbose,EraseFlash=none"
-            core: "esp32:esp32@2.0.11"
         exclude:
           - example: "BASIC"
             fqbn: "esp32:esp32:esp32c3"
@@ -33,28 +36,25 @@ jobs:
             fqbn: "esp8266:esp8266:d1_mini"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - run:
-          curl -fsSL https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh |
-          sh -s 0.35.3
-      - run: bin/arduino-cli --verbose core install '${{ matrix.core }}'
-          --additional-urls '${{ matrix.core_url }}'
-      - run: bin/arduino-cli --verbose lib install
-          WiFiManager@2.0.16-rc.2
-          Arduino_JSON@0.2.0
-          U8g2@2.34.22
-      # In some cases, actions/checkout@v4 will check out a detached HEAD; for
-      # example, this happens on pull request events, where an hypothetical
-      # PR merge commit is checked out. This tends to confuse
-      # `arduino-cli lib install --git-url`, making it fail with errors such as:
-      #   Error installing Git Library: Library install failed: object not found
-      # Create and check out a dummy branch to work around this issue.
-      - run: git checkout -b check
-      - run: bin/arduino-cli --verbose lib install --git-url .
-        env:
-          ARDUINO_LIBRARY_ENABLE_UNSAFE_INSTALL: "true"
-      - run: bin/arduino-cli --verbose compile 'examples/${{ matrix.example }}'
-          --fqbn '${{ matrix.fqbn }}' --board-options '${{ matrix.board_options }}'
+      - uses: actions/checkout@v4.2.2
+      - uses: arduino/compile-sketches@v1.1.2
+        with:
+          fqbn: ${{ matrix.fqbn }}
+          sketch-paths: |
+            examples/${{ matrix.example }}
+          libraries: |
+            - source-path: ./
+          cli-compile-flags: |
+            - --warnings
+            - none
+            - --board-options
+            - "${{ matrix.board_options }}"
+          platforms: |
+            - name: ${{ matrix.core }}
+              version: ${{ matrix.core_version}}
+              source-url: ${{ matrix.core_url }}
+          enable-deltas-report: true
+
       # TODO: at this point it would be a good idea to run some smoke tests on
       # the resulting image (e.g. that it boots successfully and sends metrics)
       # but that would either require a high fidelity device emulator, or a


### PR DESCRIPTION
Instead of straight CLI, uses the arduino/compile-sketches action.

One immediate benefit is enabling deltas reports
https://github.com/arduino/compile-sketches/tree/v1.1.2/?tab=readme-ov-file#enable-deltas-report

This can show the change in flash and ram compared to the previous run https://github.com/MallocArray/arduino/actions/runs/12954136400/job/36135424360
```
Compiling sketch: examples/OneOpenAir
Compilation time elapsed: 6s
Change in flash: 147290 (7.49%)
Change in RAM for global variables: 2280 (0.7%)
```

A future improvement could be to also add https://github.com/arduino/report-size-deltas that can generate a comment on a PR that also shows the delta information.