### PR TITLE
Fix display 0 measurements value on boot

### DIFF
--- a/examples/OneOpenAir/OneOpenAir.ino
+++ b/examples/OneOpenAir/OneOpenAir.ino
@@ -268,15 +268,17 @@ void setup() {
     oledDisplay.setBrightness(configuration.getDisplayBrightness());
   }
 
-  // Update display and led bar after finishing setup to show dashboard
-  updateDisplayAndLedBar();
+  // Reset display and post schedulers to make sure measurements value already available
+  dispLedSchedule.update();
+  agApiPostSchedule.update();
 }
 
 void loop() {
-  /** Handle schedule */
+  /** Run schedulers */
   dispLedSchedule.run();
   configSchedule.run();
   agApiPostSchedule.run();
+  watchdogFeedSchedule.run();
 
   if (configuration.hasSensorS8) {
     co2Schedule.run();
@@ -310,15 +312,13 @@ void loop() {
     }
   }
 
-  watchdogFeedSchedule.run();
-
   /** Check for handle WiFi reconnect */
   wifiConnector.handle();
 
   /** factory reset handle */
   factoryConfigReset();
 
-  /** check that local configura changed then do some action */
+  /** check that local configuration changed then do some action */
   configUpdateHandle();
 
   /** Firmware check for update handle */

--- a/examples/OneOpenAir/OneOpenAir.ino
+++ b/examples/OneOpenAir/OneOpenAir.ino
@@ -268,8 +268,7 @@ void setup() {
     oledDisplay.setBrightness(configuration.getDisplayBrightness());
   }
 
-  // Reset display and post schedulers to make sure measurements value already available
-  dispLedSchedule.update();
+  // Reset post schedulers to make sure measurements value already available
   agApiPostSchedule.update();
 }
 

--- a/src/AgValue.cpp
+++ b/src/AgValue.cpp
@@ -31,6 +31,45 @@ Measurements::Measurements() {
 #ifndef ESP8266
   _resetReason = (int)ESP_RST_UNKNOWN;
 #endif
+  
+  /* Set invalid value for each measurements as default value when initialized*/
+  _temperature[0].update.avg = utils::getInvalidTemperature();
+  _temperature[1].update.avg = utils::getInvalidTemperature();
+  _humidity[0].update.avg = utils::getInvalidHumidity();
+  _humidity[1].update.avg = utils::getInvalidHumidity();
+  _co2.update.avg = utils::getInvalidCO2();
+  _tvoc.update.avg = utils::getInvalidVOC();
+  _tvoc_raw.update.avg = utils::getInvalidVOC();
+  _nox.update.avg = utils::getInvalidNOx();
+  _nox_raw.update.avg = utils::getInvalidNOx();
+
+  _pm_03_pc[0].update.avg = utils::getInvalidPmValue();
+  _pm_03_pc[1].update.avg = utils::getInvalidPmValue();
+  _pm_05_pc[0].update.avg = utils::getInvalidPmValue();
+  _pm_05_pc[1].update.avg = utils::getInvalidPmValue();
+  _pm_5_pc[0].update.avg = utils::getInvalidPmValue();
+  _pm_5_pc[1].update.avg = utils::getInvalidPmValue();
+  
+  _pm_01[0].update.avg = utils::getInvalidPmValue();
+  _pm_01_sp[0].update.avg = utils::getInvalidPmValue();
+  _pm_01_pc[0].update.avg = utils::getInvalidPmValue();
+  _pm_01[1].update.avg = utils::getInvalidPmValue();
+  _pm_01_sp[1].update.avg = utils::getInvalidPmValue();
+  _pm_01_pc[1].update.avg = utils::getInvalidPmValue();
+
+  _pm_25[0].update.avg = utils::getInvalidPmValue();
+  _pm_25_sp[0].update.avg = utils::getInvalidPmValue();
+  _pm_25_pc[0].update.avg = utils::getInvalidPmValue();
+  _pm_25[1].update.avg = utils::getInvalidPmValue();
+  _pm_25_sp[1].update.avg = utils::getInvalidPmValue();
+  _pm_25_pc[1].update.avg = utils::getInvalidPmValue();
+
+  _pm_10[0].update.avg = utils::getInvalidPmValue();
+  _pm_10_sp[0].update.avg = utils::getInvalidPmValue();
+  _pm_10_pc[0].update.avg = utils::getInvalidPmValue();
+  _pm_10[1].update.avg = utils::getInvalidPmValue();
+  _pm_10_sp[1].update.avg = utils::getInvalidPmValue();
+  _pm_10_pc[1].update.avg = utils::getInvalidPmValue();
 }
 
 void Measurements::maxPeriod(MeasurementType type, int max) {


### PR DESCRIPTION
### Problem

On version 3.1.13 and 3.1.21, when monitor finish setup() function, display show 0 values for all measurements for a moment.

### Solution

Make sure scheduler for sensor readings run first before display to oled and post to server. By reset display and post data scheduler at the end of setup function.

https://github.com/user-attachments/assets/867325e9-e865-4960-a468-d6d850ab05eb


