### PR TITLE
HTTP client failed/timeout to establish connection to airgradient server

### DIFF
--- a/src/AgApiClient.cpp
+++ b/src/AgApiClient.cpp
@@ -59,6 +59,7 @@ bool AgApiClient::fetchServerConfiguration(void) {
 #else
   HTTPClient client;
   client.setTimeout(timeoutMs);
+  client.setConnectTimeout(timeoutMs);
   if (apiRootChanged) {
     // If apiRoot is changed, assume not using https
     if (client.begin(uri) == false) {
@@ -134,6 +135,7 @@ bool AgApiClient::postToServer(String data) {
 #else
   HTTPClient client;
   client.setTimeout(timeoutMs);
+  client.setConnectTimeout(timeoutMs);
   if (apiRootChanged) {
     // If apiRoot is changed, assume not using https
     if (client.begin(uri) == false) {

--- a/src/AgApiClient.cpp
+++ b/src/AgApiClient.cpp
@@ -58,8 +58,8 @@ bool AgApiClient::fetchServerConfiguration(void) {
   }
 #else
   HTTPClient client;
-  client.setTimeout(timeoutMs);
-  client.setConnectTimeout(timeoutMs);
+  client.setConnectTimeout(timeoutMs); // Set timeout when establishing connection to server 
+  client.setTimeout(timeoutMs); // Timeout when waiting for response from AG server
   if (apiRootChanged) {
     // If apiRoot is changed, assume not using https
     if (client.begin(uri) == false) {
@@ -134,8 +134,8 @@ bool AgApiClient::postToServer(String data) {
   }
 #else
   HTTPClient client;
-  client.setTimeout(timeoutMs);
-  client.setConnectTimeout(timeoutMs);
+  client.setConnectTimeout(timeoutMs); // Set timeout when establishing connection to server 
+  client.setTimeout(timeoutMs); // Timeout when waiting for response from AG server
   if (apiRootChanged) {
     // If apiRoot is changed, assume not using https
     if (client.begin(uri) == false) {

--- a/src/AgApiClient.h
+++ b/src/AgApiClient.h
@@ -31,7 +31,7 @@ private:
   bool getConfigFailed;
   bool postToServerFailed;
   bool notAvailableOnDashboard = false; // Device not setup on Airgradient cloud dashboard.
-  uint16_t timeoutMs = 10000;           // Default set to 10s
+  uint16_t timeoutMs = 15000;           // Default set to 15s
 
 public:
   AgApiClient(Stream &stream, Configuration &config);


### PR DESCRIPTION
### Problem

Sometimes when device have bad internet connection, http client failed to connect to airgradient server. That makes these errors occur

```
[2417017][E][WiFiClientSecure.cpp:144] connect(): start_ssl_client: -1
[ApiClient] Info: GET: https://hw.airgradient.com/sensors/airgradient:aaaaaaaaaa/one/config
[ApiClient] Info: Return code: -1
```

```
[887570][E][WiFiGeneric.cpp:1583] hostByName(): DNS Failed for hw.airgradient.com
[ApiClient] Info: GET: https://hw.airgradient.com/sensors/airgradient:aaaaaaaaaaa/one/config
[ApiClient] Info: Return code: -1
```

Return code indicate connection refused, but it is misleading. After set log level to verbose, it shows the problem:

```
13:20:22.092 > [321705][V][HTTPClient.cpp:252] beginInternal(): url: https://hw.airgradient.com/sensors/airgradient:aaaaaaa/measures
13:20:22.222 > [321835][D][HTTPClient.cpp:303] beginInternal(): protocol: https, host: hw.airgradient.com port: 443 url: /sensors/airgradient:aaaaaaaa/measures
13:20:22.379 > [321991][D][HTTPClient.cpp:598] sendRequest(): request type: 'POST' redirCount: 0
13:20:22.379 > 
13:20:22.468 > [322080][V][ssl_client.cpp:62] start_ssl_client(): Free internal heap before TLS 184080
13:20:22.560 > [322173][V][ssl_client.cpp:68] start_ssl_client(): Starting socket
13:20:27.633 > [327246][I][ssl_client.cpp:112] start_ssl_client(): select returned due to timeout 5000 ms for fd 49
13:20:27.740 > [327352][E][WiFiClientSecure.cpp:144] connect(): start_ssl_client: -1
13:20:27.814 > [327427][V][ssl_client.cpp:321] stop_ssl_socket(): Cleaning SSL connection.
13:20:27.894 > [327507][D][HTTPClient.cpp:1163] connect(): failed connect to hw.airgradient.com:443
13:20:27.984 > [327597][W][HTTPClient.cpp:1483] returnError(): error(-1): connection refused
13:20:28.067 > [327680][D][HTTPClient.cpp:408] disconnect(): tcp is closed
13:20:28.067 > 
13:20:28.133 > [ApiClient] Info: POST: https://hw.airgradient.com/sensors/airgradient:aaaaaaaa/measures
13:20:28.133 > [ApiClient] Info: Return code: -1
13:20:28.133 > [ApiClient] Error: Post response failed code: -1
13:20:28.133 > [327746][V][ssl_client.cpp:321] stop_ssl_socket(): Cleaning SSL connection.
13:20:28.213 > [327826][V][ssl_client.cpp:321] stop_ssl_socket(): Cleaning SSL connection.
```

Below there's this log that says `select returned due to timeout 5000 ms for fd 49`. And after looking through the HTTPClient, timeout occur when attempt connect to the server (connection handshake), not from the actual http data transfer.

### Solution

Increase timeout for establishing a connection to the server