### PR TITLE
docs: added some details about how to compile and contribute changes upstream

### DIFF
--- a/docs/howto-compile.md
+++ b/docs/howto-compile.md
@@ -82,9 +82,11 @@ Choose based on how python installed on your machine. But most user, using `apt`
 
 ## How to contribute
 
+The instructions above are the instructions for how to build an official release of the AirGradient firmware using the Arduino IDE. If you intend to make changes that will you intent to contribute back to the main project, instead of installing the AirGradient library, check out the repo at `Documents/Arduino/libraries` (for Windows and Mac), or `~/Arduino/Libraries` (Linux). If you installed the library, you can remove it from the library manager in the Arduino IDE, or just delete the directory.
+
 Please follow github [contributing to a project](https://docs.github.com/en/get-started/exploring-projects-on-github/contributing-to-a-project) tutorial to contribute to this project.
 
 There are 2 environment options to compile this project, PlatformIO and ArduinoIDE.
 
 - For PlatformIO, it should work out of the box
-- For arduino, files in `src` folder and also from `Examples` can be modified at `Documents/Arduino/libraries` for windows and mac, and `~/Arduino/Libraries` for linux
+- For arduino, files in `src` folder and also from `Examples` can be modified at `Documents/Arduino/libraries` for Windows and Mac, and `~/Arduino/Libraries` for Linux


### PR DESCRIPTION
I've verified that the git repo can be checked out with an arbitrary folder name (e.g. leaving it as the repo name: `arduino`) and the Arduino IDE will still pick it up. The AirGradient section still appears under File -> Examples, just as in the screenshots.

I tested these instructions on Debian 12, however they should work on all platforms as this is all related to how the IDE picks up libraries.