### PR TITLE
fix: don't contact AG server if cloud connection is disabled

### DIFF
--- a/examples/OneOpenAir/OneOpenAir.ino
+++ b/examples/OneOpenAir/OneOpenAir.ino
@@ -872,19 +872,23 @@ void initializeNetwork() {
   checkForUpdateSchedule.update();
 #endif
 
-  apiClient.fetchServerConfiguration();
-  configSchedule.update();
-  if (apiClient.isFetchConfigurationFailed()) {
-    if (ag->isOne()) {
-      if (apiClient.isNotAvailableOnDashboard()) {
-        stateMachine.displaySetAddToDashBoard();
-        stateMachine.displayHandle(AgStateMachineWiFiOkServerOkSensorConfigFailed);
-      } else {
-        stateMachine.displayClearAddToDashBoard();
+  if (! configuration.isCloudConnectionDisabled()) {
+    apiClient.fetchServerConfiguration();
+    configSchedule.update();
+    if (apiClient.isFetchConfigurationFailed()) {
+      if (ag->isOne()) {
+        if (apiClient.isNotAvailableOnDashboard()) {
+          stateMachine.displaySetAddToDashBoard();
+          stateMachine.displayHandle(AgStateMachineWiFiOkServerOkSensorConfigFailed);
+        } else {
+          stateMachine.displayClearAddToDashBoard();
+        }
       }
+      stateMachine.handleLeds(AgStateMachineWiFiOkServerOkSensorConfigFailed);
+      delay(DISPLAY_DELAY_SHOW_CONTENT_MS);
+    } else {
+      ledBarEnabledUpdate();
     }
-    stateMachine.handleLeds(AgStateMachineWiFiOkServerOkSensorConfigFailed);
-    delay(DISPLAY_DELAY_SHOW_CONTENT_MS);
   } else {
     ledBarEnabledUpdate();
   }


### PR DESCRIPTION
This should fix the issue where the firmware calls out to the AirGradient server even when "Prevent Connection to AirGradient Server" is checked.

This was brought up in the [ability to turn off data to external networks](https://forum.airgradient.com/t/ability-to-turn-off-data-to-external-networks/3529?u=hestia) post.

It was mentioned in [the forum](https://forum.airgradient.com/t/we-dont-love-subscriptions-but-the-airgradient-dashboard-needs-them/3250/15?u=hestia) that there is an intent to fix this issue.

This change needs tested to verify it completely disables all connections to the AG server. It compiles fine, but I haven't done a full network analysis to confirm it doesn't call out elsewhere or cause any other problem by no longer fetching the server configuration.