### PR TITLE
Enable cellular AT command debug when in network registration

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -38,6 +38,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4.2.2
         with:
+          fetch-depth: 0
           submodules: 'true'
       - uses: arduino/compile-sketches@v1.1.2
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,7 @@ build
 /.idea/
 .pio
 .cache
+.clangd
 logs
+gen_compile_commands.py
 compile_commands.json

--- a/examples/OneOpenAir/OneOpenAir.ino
+++ b/examples/OneOpenAir/OneOpenAir.ino
@@ -934,6 +934,11 @@ void initializeNetwork() {
     networkOption = UseWifi;
   }
 
+  if (networkOption == UseCellular) {
+    // Enable serial stream debugging to check the AT command when doing registration 
+    agSerial->setDebug(true);
+  }
+
   if (!agClient->begin(ag->deviceId().c_str())) {
     oledDisplay.setText("Client", "initialization", "failed");
     delay(5000);
@@ -941,6 +946,11 @@ void initializeNetwork() {
     delay(2500);
     oledDisplay.setText("", "", "");
     ESP.restart();
+  }
+
+  if (networkOption == UseCellular) {
+    // Disabling it again
+    agSerial->setDebug(false);
   }
 
   if (networkOption == UseWifi) {
@@ -1495,11 +1505,13 @@ void networkingTask(void *args) {
     else if (networkOption == UseCellular) {
       if (agClient->isClientReady() == false) {
         Serial.println("Cellular client not ready, ensuring connection...");
+        agSerial->setDebug(true); 
         if (agClient->ensureClientConnection() == false) {
           Serial.println("Cellular client connection not ready, retry in 5s...");
           delay(5000);
           continue;
         }
+        agSerial->setDebug(false);
       }
     }
 


### PR DESCRIPTION
## Changes

- Enable cellular AT command debug when in network registration. To better understand if cellular module not able to connect to the network
- On boot, airgradient-client change cellular init timeout to 5 mins