### PR TITLE
Restarting cellular module when cellular client is not ready

### DIFF
--- a/examples/OneOpenAir/OneOpenAir.ino
+++ b/examples/OneOpenAir/OneOpenAir.ino
@@ -813,8 +813,6 @@ static void openAirInit(void) {
       Serial.println("CO2 S8 sensor not found");
       Serial.println("Can not detect S8 run mode 'PPT'");
       fwMode = FW_MODE_O_1PPT;
-
-      Serial0.end();
       delay(200);
     } else {
       Serial.println("Found S8 on Serial0");


### PR DESCRIPTION
## Changes

- When cellular client is not ready, the reason not only because of network not registered or module not responding, but can be something else (eg. HTTP AT command always return error). To make sure, will do cellular module power recycle and re-start network registration. _Changes on airgradient-client_
- Fix esp_log not come out on O-PP model