### PR TITLE
Include cellular signal in RSSI (dbm) when post measures

### DIFF
--- a/src/AgValue.cpp
+++ b/src/AgValue.cpp
@@ -827,6 +827,12 @@ std::string Measurements::buildMeasuresPayload(Measures &mc) {
     oss << std::round(mc.pm_03_pc[1]);
   }
 
+  oss << ",";
+
+  if (mc.signal < 0) {
+    oss << mc.signal;
+  }
+
   return oss.str();
 }
 


### PR DESCRIPTION
## Changes

- Include cellular signal in RSSI (dbm) when post measures
- But if signal value invalid, then don't include it. Follow the convention of other measures type.