### PR TITLE
Improve cellular client reconnection

### DIFF
--- a/examples/OneOpenAir/OneOpenAir.ino
+++ b/examples/OneOpenAir/OneOpenAir.ino
@@ -1571,9 +1571,6 @@ void networkingTask(void *args) {
   configSchedule.update();
   transmissionSchedule.update();
 
-
-  uint32_t startTime = millis();
-
   while (1) {
     // Handle reconnection based on mode
     if (networkOption == UseWifi) {

--- a/examples/OneOpenAir/OneOpenAir.ino
+++ b/examples/OneOpenAir/OneOpenAir.ino
@@ -76,6 +76,7 @@ CC BY-SA 4.0 Attribution-ShareAlike 4.0 International License
 #define DISPLAY_DELAY_SHOW_CONTENT_MS 2000             /** ms */
 #define FIRMWARE_CHECK_FOR_UPDATE_MS (60 * 60 * 1000)  /** ms */
 
+#define MEASUREMENT_TRANSMIT_CYCLE 3
 #define MAXIMUM_MEASUREMENT_CYCLE_QUEUE 80
 #define RESERVED_MEASUREMENT_CYCLE_CAPACITY 10
 
@@ -1361,6 +1362,13 @@ void postUsingCellular() {
   if (queueSize == 0) {
     Serial.println("Skipping transmission, measurementCycle empty");
     xSemaphoreGive(mutexMeasurementCycleQueue);
+    return;
+  }
+
+  // Check queue size if its ready to transmit
+  // It is ready if size is 1 or divisible by 3 
+  if (queueSize != 1 && (queueSize % MEASUREMENT_TRANSMIT_CYCLE) > 0) {
+    Serial.printf("Not ready to transmit, queue size are %d\n", queueSize);
     return;
   }
 

--- a/examples/OneOpenAir/OneOpenAir.ino
+++ b/examples/OneOpenAir/OneOpenAir.ino
@@ -92,7 +92,7 @@ CC BY-SA 4.0 Attribution-ShareAlike 4.0 International License
 #define GPIO_EXPANSION_CARD_POWER 4
 #define GPIO_IIC_RESET 3
 
-#define MICROS_TO_MINUTES() ((uint32_t)(esp_timer_get_time() / 1000 / 1000 / 60))
+#define MINUTES() ((uint32_t)(esp_timer_get_time() / 1000 / 1000 / 60))
 
 static MqttClient mqttClient(Serial);
 static TaskHandle_t mqttTask = NULL;
@@ -1526,7 +1526,7 @@ void networkSignalCheck() {
 */
 void restartIfCeClientIssueOverTwoHours() {
   if (agCeClientProblemDetectedTime > 0 &&
-      (MICROS_TO_MINUTES() - agCeClientProblemDetectedTime) >
+      (MINUTES() - agCeClientProblemDetectedTime) >
           TIMEOUT_WAIT_FOR_CELLULAR_MODULE_READY) {
     // Give up wait
     Serial.println("Rebooting because CE client issues for 2 hours detected");
@@ -1584,7 +1584,7 @@ void networkingTask(void *args) {
       if (agClient->isClientReady() == false) {
         // Start time if value still default
         if (agCeClientProblemDetectedTime == 0) {
-          agCeClientProblemDetectedTime = MICROS_TO_MINUTES();
+          agCeClientProblemDetectedTime = MINUTES();
         }
 
         // Enable at command debug
@@ -1596,7 +1596,7 @@ void networkingTask(void *args) {
 
         // Power cycling cellular module due to network issues for more than 1 hour
         bool resetModule = true;
-        if ((MICROS_TO_MINUTES() - agCeClientProblemDetectedTime) >
+        if ((MINUTES() - agCeClientProblemDetectedTime) >
             TIME_TO_START_POWER_CYCLE_CELLULAR_MODULE) {
           Serial.println("The CE client hasn't recovered in more than 1 hour, "
                          "performing a power cycle");


### PR DESCRIPTION
## Changes

1. Power cycle cellular module control directly on main, if airgradient client not ready for more than 1 hour
2. If in 2 hour airgradient client still not ready, then esp restart. Has redundant check in both main and networking tasks.
3. Transmit measures only if measurement cycle queue size is divisible by 3