### PR TITLE
Fix incorrect TVOC / NOx values when when network option is cellular 

### DIFF
--- a/examples/OneOpenAir/OneOpenAir.ino
+++ b/examples/OneOpenAir/OneOpenAir.ino
@@ -584,7 +584,7 @@ void otaHandlerCallback(AirgradientOTA::OtaResult result, const char *msg) {
     Serial.println("Firmware update starting...");
     if (configuration.hasSensorSGP && networkOption == UseCellular) {
       // Temporary pause SGP41 task while cellular firmware update is in progress
-      ag->sgp41.pauseHandle();
+      ag->sgp41.pause();
     }
     displayExecuteOta(result, fwNewVersion, 0);
     break;
@@ -594,13 +594,15 @@ void otaHandlerCallback(AirgradientOTA::OtaResult result, const char *msg) {
     displayExecuteOta(result, "", std::stoi(msg));
     break;
   case AirgradientOTA::Failed:
+      displayExecuteOta(result, "", 0);
+      if (configuration.hasSensorSGP && networkOption == UseCellular) {
+        // Cellular firmware update finish, resuming SGP41 task
+        ag->sgp41.resume();
+      }
+      break;
   case AirgradientOTA::Skipped:
   case AirgradientOTA::AlreadyUpToDate:
     displayExecuteOta(result, "", 0);
-    if (configuration.hasSensorSGP && networkOption == UseCellular) {
-      // Cellular firmware update finish, resuming SGP41 task
-      ag->sgp41.resumeHandle();
-    }
     break;
   case AirgradientOTA::Success:
     displayExecuteOta(result, "", 0);

--- a/examples/OneOpenAir/OneOpenAir.ino
+++ b/examples/OneOpenAir/OneOpenAir.ino
@@ -596,7 +596,6 @@ void otaHandlerCallback(AirgradientOTA::OtaResult result, const char *msg) {
   case AirgradientOTA::Failed:
       displayExecuteOta(result, "", 0);
       if (configuration.hasSensorSGP && networkOption == UseCellular) {
-        // Cellular firmware update finish, resuming SGP41 task
         ag->sgp41.resume();
       }
       break;

--- a/src/Sgp41/Sgp41.cpp
+++ b/src/Sgp41/Sgp41.cpp
@@ -132,7 +132,7 @@ void Sgp41::handle(void) {
 
 #else
 
-void Sgp41::pauseHandle() {
+void Sgp41::pause() {
   onPause = true;
   Serial.println("Pausing SGP41 handler task");
   // Set latest value to invalid
@@ -142,9 +142,9 @@ void Sgp41::pauseHandle() {
   nox = utils::getInvalidNOx();
 } 
 
-void Sgp41::resumeHandle() {
+void Sgp41::resume() {
   onPause = false;
-  Serial.println("Resume SGP41 handler task");
+  Serial.println("Resuming SGP41 handler task");
 }
 
 /**

--- a/src/Sgp41/Sgp41.cpp
+++ b/src/Sgp41/Sgp41.cpp
@@ -131,6 +131,22 @@ void Sgp41::handle(void) {
 }
 
 #else
+
+void Sgp41::pauseHandle() {
+  onPause = true;
+  Serial.println("Pausing SGP41 handler task");
+  // Set latest value to invalid
+  tvocRaw = utils::getInvalidVOC();
+  tvoc = utils::getInvalidVOC();
+  noxRaw = utils::getInvalidNOx();
+  nox = utils::getInvalidNOx();
+} 
+
+void Sgp41::resumeHandle() {
+  onPause = false;
+  Serial.println("Resume SGP41 handler task");
+}
+
 /**
  * @brief Handle the sensor conditioning and run time udpate value, This method
  * must not call, it's called on private task
@@ -152,6 +168,11 @@ void Sgp41::_handle(void) {
   uint16_t srawVoc, srawNox;
   for (;;) {
     vTaskDelay(pdMS_TO_TICKS(1000));
+
+    if (onPause) {
+      continue;
+    }
+
     if (getRawSignal(srawVoc, srawNox)) {
       tvocRaw = srawVoc;
       noxRaw = srawNox;

--- a/src/Sgp41/Sgp41.h
+++ b/src/Sgp41/Sgp41.h
@@ -19,9 +19,9 @@ public:
   void handle(void);
 #else
   /* pause _handle task to read sensor */
-  void pauseHandle();
+  void pause();
   /* resume _handle task to read sensor */
-  void resumeHandle();
+  void resume();
   void _handle(void);
 #endif
   void end(void);

--- a/src/Sgp41/Sgp41.h
+++ b/src/Sgp41/Sgp41.h
@@ -18,6 +18,10 @@ public:
   bool begin(TwoWire &wire, Stream &stream);
   void handle(void);
 #else
+  /* pause _handle task to read sensor */
+  void pauseHandle();
+  /* resume _handle task to read sensor */
+  void resumeHandle();
   void _handle(void);
 #endif
   void end(void);
@@ -32,6 +36,7 @@ public:
   int getTvocLearningOffset(void);
 
 private:
+  bool onPause = false;
   bool onConditioning = true;
   bool ready = false;
   bool _isBegin = false;


### PR DESCRIPTION
## Changes

- Add a pause and resume SGP41 reading to its task, so no need to reset SGP41 algorithm object
- Use latest airgradient-ota library, by improving ota sequence to have a more accurate event. Please see: #https://github.com/airgradienthq/airgradient-ota/pull/2 . Because of this, no need to pause SGP41 task every time doing OTA check. Only pause when actually know that firmware update is available.

