### PR TITLE
Fix calling airgradient client before initialization on open metrics

### DIFF
--- a/examples/OneOpenAir/OneOpenAir.ino
+++ b/examples/OneOpenAir/OneOpenAir.ino
@@ -210,7 +210,7 @@ void setup() {
   oledDisplay.setAirGradient(ag);
   stateMachine.setAirGradient(ag);
   wifiConnector.setAirGradient(ag);
-  openMetrics.setAirGradient(ag, agClient);
+  openMetrics.setAirGradient(ag);
   localServer.setAirGraident(ag);
   measurements.setAirGradient(ag);
 
@@ -988,6 +988,9 @@ void initializeNetwork() {
     oledDisplay.setText("", "", "");
     ESP.restart();
   }
+
+  // Provide openmetrics to have access to last transmission result 
+  openMetrics.setAirgradientClient(agClient);
 
   if (networkOption == UseCellular) {
     // Disabling it again

--- a/examples/OneOpenAir/OpenMetrics.cpp
+++ b/examples/OneOpenAir/OpenMetrics.cpp
@@ -6,8 +6,11 @@ OpenMetrics::OpenMetrics(Measurements &measure, Configuration &config,
 
 OpenMetrics::~OpenMetrics() {}
 
-void OpenMetrics::setAirGradient(AirGradient *ag, AirgradientClient *client) { 
+void OpenMetrics::setAirGradient(AirGradient *ag) { 
   this->ag = ag; 
+}
+
+void OpenMetrics::setAirgradientClient(AirgradientClient *client) {
   this->agClient = client;
 }
 

--- a/examples/OneOpenAir/OpenMetrics.h
+++ b/examples/OneOpenAir/OpenMetrics.h
@@ -19,7 +19,8 @@ public:
   OpenMetrics(Measurements &measure, Configuration &config,
               WifiConnector &wifiConnector);
   ~OpenMetrics();
-  void setAirGradient(AirGradient *ag, AirgradientClient *client);
+  void setAirGradient(AirGradient *ag);
+  void setAirgradientClient(AirgradientClient *client);
   const char *getApiContentType(void);
   const char* getApi(void);
   String getPayload(void);


### PR DESCRIPTION
## Changes

Previously, `airgradientClient` was passed to `openmetrics` before it was initialized. This has been fixed by separating the passing of `airgradient` and `airgradientClient` to `openmetrics`, allowing `airgradientClient` to be passed only after it has been initialized.