### PR TITLE
Fix failing to clone submodules recursively

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "src/Libraries/airgradient-client"]
 	path = src/Libraries/airgradient-client
-	url = git@github.com:airgradienthq/airgradient-client.git
+	url = ../../airgradienthq/airgradient-client.git
 [submodule "src/Libraries/airgradient-ota"]
 	path = src/Libraries/airgradient-ota
-	url = git@github.com:airgradienthq/airgradient-ota.git
+	url = ../../airgradienthq/airgradient-ota.git


### PR DESCRIPTION
This should fix #307 by using a relative path for the submodule URLs. Users that clone the repo with HTTPS will also clone the submodules with HTTPS, and users that clone the repo with SSH will clone the submodules with SSH.

We keep the username in the path so that forks don't need to also fork the submodules.

For example, the configuration below would not work for a user that forks only the main repo and not the submodules because git would look for the submodules in the namespace of the forking user.

```
[submodule "src/Libraries/airgradient-client"]
    path = src/Libraries/airgradient-client
    url = ../airgradient-client.git
[submodule "src/Libraries/airgradient-ota"]
    path = src/Libraries/airgradient-ota
    url = ../airgradient-ota.git
```

---

This can be tested by cloning the branch on a machine without an SSH key allowed on your Github account.

Clone with HTTPS to make sure HTTPS cloning works:
```sh
$ git clone --recursive -b fix/submodule-url https://github.com/ccoley/arduino.git airgradient-test
Cloning into 'airgradient-test'...
...
Submodule 'src/Libraries/airgradient-client' (https://github.com/airgradienthq/airgradient-client.git) registered for path 'src/Libraries/airgradient-client'
Submodule 'src/Libraries/airgradient-ota' (https://github.com/airgradienthq/airgradient-ota.git) registered for path 'src/Libraries/airgradient-ota'
Cloning into '/home/ccoley/projects/airgradient-test/src/Libraries/airgradient-client'...
...
Cloning into '/home/ccoley/projects/airgradient-test/src/Libraries/airgradient-ota'...
...
Submodule path 'src/Libraries/airgradient-client': checked out 'a4ac14936e91bca7a660536293f2e52297798875'
Submodule path 'src/Libraries/airgradient-ota': checked out '81a0189f54c45485d4a58de29b394105466e5530'
```

Then try cloning with SSH after making sure you've removed your SSH key from your Github account. This clone is expected to fail:
```sh
$ git clone --recursive -b fix/submodule-url git@github.com:ccoley/arduino.git airgradient-test2
Cloning into 'airgradient-test2'...
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```

Then re-add your SSH key to your Github account and try again. This clone should succeed:
```sh
$ git clone --recursive -b fix/submodule-url git@github.com:ccoley/arduino.git airgradient-test3
Cloning into 'airgradient-test3'...
...
Submodule 'src/Libraries/airgradient-client' (git@github.com:airgradienthq/airgradient-client.git) registered for path 'src/Libraries/airgradient-client'
Submodule 'src/Libraries/airgradient-ota' (git@github.com:airgradienthq/airgradient-ota.git) registered for path 'src/Libraries/airgradient-ota'
Cloning into '/home/ccoley/projects/airgradient-test3/src/Libraries/airgradient-client'...
...
Cloning into '/home/ccoley/projects/airgradient-test3/src/Libraries/airgradient-ota'...
...
Submodule path 'src/Libraries/airgradient-client': checked out 'a4ac14936e91bca7a660536293f2e52297798875'
Submodule path 'src/Libraries/airgradient-ota': checked out '81a0189f54c45485d4a58de29b394105466e5530'
```