### PR TITLE
Fix bootloop when cloud connection is disabled

### DIFF
--- a/examples/OneOpenAir/OneOpenAir.ino
+++ b/examples/OneOpenAir/OneOpenAir.ino
@@ -1644,7 +1644,7 @@ void networkingTask(void *args) {
     // If connection to AirGradient server disable don't run config and transmission schedule
     if (configuration.isCloudConnectionDisabled()) {
       delay(1000);
-      return;
+      continue;
     }
 
     // Run scheduler


### PR DESCRIPTION
## Problem

Bootloop happen when cloud connection disabled because of calling return inside a task function making it crash. 

Issue: #312 

## Changes

- Change `return` to `continue` to ignore the rest of transmission code. 
- Ignore OTA check on boot