### PR TITLE
Improve measurements logging

### DIFF
--- a/examples/OneOpenAir/OneOpenAir.ino
+++ b/examples/OneOpenAir/OneOpenAir.ino
@@ -143,6 +143,7 @@ static void updatePm(void);
 static void sendDataToServer(void);
 static void tempHumUpdate(void);
 static void co2Update(void);
+static void printMeasurements();
 static void mdnsInit(void);
 static void createMqttTask(void);
 static void initMqtt(void);
@@ -172,6 +173,7 @@ AgSchedule tvocSchedule(SENSOR_TVOC_UPDATE_INTERVAL, updateTvoc);
 AgSchedule watchdogFeedSchedule(60000, wdgFeedUpdate);
 AgSchedule checkForUpdateSchedule(FIRMWARE_CHECK_FOR_UPDATE_MS, checkForFirmwareUpdate);
 AgSchedule networkSignalCheckSchedule(10000, networkSignalCheck);
+AgSchedule printMeasurementsSchedule(6000, printMeasurements);
 
 void setup() {
   /** Serial for print debug message */
@@ -217,9 +219,6 @@ void setup() {
   /** Init sensor */
   boardInit();
   setMeasurementMaxPeriod();
-
-  // Comment below line to disable debug measurement readings
-  measurements.setDebug(true);
 
   bool connectToNetwork = true;
   if (ag->isOne()) { // Offline mode only available for indoor monitor
@@ -364,6 +363,9 @@ void loop() {
     }
   }
 
+  /* Run measurement schedule */
+  printMeasurementsSchedule.run();
+
   /** factory reset handle */
   factoryConfigReset();
 
@@ -383,6 +385,10 @@ static void co2Update(void) {
   } else {
     measurements.update(Measurements::CO2, utils::getInvalidCO2());
   }
+}
+
+void printMeasurements() {
+  measurements.printCurrentAverage();
 }
 
 static void mdnsInit(void) {

--- a/src/AgValue.h
+++ b/src/AgValue.h
@@ -88,6 +88,8 @@ public:
     PM10_PC, // Particle 10 count
   };
 
+  void printCurrentAverage();
+
   /**
    * @brief Set each MeasurementType maximum period length for moving average
    *
@@ -257,6 +259,8 @@ private:
    * abort program if invalid
    */
   void validateChannel(int ch);
+
+  void printCurrentPMAverage(int ch);
 
   JSONVar buildOutdoor(bool localServer, AgFirmwareMode fwMode);
   JSONVar buildIndoor(bool localServer);


### PR DESCRIPTION
## Changes

Improve logging by log measurement values on a same schedule and more readable format

Example:

```
14:15:02.438 > CO2 = 153.00 ppm
14:15:02.438 > Temperature = 32.80 C
14:15:02.438 > Relative Humidity = 72.36
14:15:02.438 > TVOC Index = 0.0
14:15:02.438 > TVOC Raw = 33738.2
14:15:02.438 > NOx Index = 0.0
14:15:02.438 > NOx Raw = 16564.3
14:15:02.439 > [1] Atmospheric PM 1.0 = 0.67 ug/m3
14:15:02.439 > [1] Atmospheric PM 2.5 = 3.33 ug/m3
14:15:02.439 > [1] Atmospheric PM 10 = 4.17 ug/m3
14:15:02.439 > [1] Standard Particle PM 1.0 = 0.67 ug/m3
14:15:02.439 > [1] Standard Particle PM 2.5 = 3.33 ug/m3
14:15:02.439 > [1] Standard Particle PM 10 = 4.17 ug/m3
14:15:02.439 > [1] Particle Count 0.3 = 285.0
14:15:02.439 > [1] Particle Count 0.5 = 256.8
14:15:02.439 > [1] Particle Count 1.0 = 1.0
14:15:02.439 > [1] Particle Count 2.5 = 0.0
14:15:02.439 > [1] Particle Count 5.0 = 0.0
14:15:02.439 > [1] Particle Count 10 = 0.0
```