### PR TITLE
Fix resizing measurement queue after post by cellular post

### DIFF
--- a/examples/OneOpenAir/OneOpenAir.ino
+++ b/examples/OneOpenAir/OneOpenAir.ino
@@ -271,6 +271,7 @@ void setup() {
 
     Serial.println("Display brightness: " + String(configuration.getDisplayBrightness()));
     oledDisplay.setBrightness(configuration.getDisplayBrightness());
+    delay(DISPLAY_DELAY_SHOW_CONTENT_MS);
   }
 
 

--- a/examples/OneOpenAir/OneOpenAir.ino
+++ b/examples/OneOpenAir/OneOpenAir.ino
@@ -1422,13 +1422,17 @@ void postUsingCellular(bool forcePost) {
 
   // Post success, remove the data that previously sent from queue
   xSemaphoreTake(mutexMeasurementCycleQueue, portMAX_DELAY);
-  measurementCycleQueue.erase(measurementCycleQueue.begin(),
-                              measurementCycleQueue.begin() + queueSize);
 
   if (measurementCycleQueue.capacity() > RESERVED_MEASUREMENT_CYCLE_CAPACITY) {
     Serial.println("measurementCycleQueue capacity more than reserved space, resizing..");
-    measurementCycleQueue.resize(RESERVED_MEASUREMENT_CYCLE_CAPACITY);
+    std::vector<Measurements::Measures> tmp;
+    tmp.reserve(RESERVED_MEASUREMENT_CYCLE_CAPACITY);
+    measurementCycleQueue.swap(tmp);
+  } else {
+    // If not more than the capacity, then just clear all the values
+    measurementCycleQueue.clear();
   }
+
   xSemaphoreGive(mutexMeasurementCycleQueue);
 }
 


### PR DESCRIPTION
_Only applied when network option is cellular_

## Problem

Previously, after processing the vector `measurementCycleQueue`, we attempted to reduce memory usage by calling .resize() function. The `resize()` function changes the size of the vector (i.e., the number of elements), not its capacity. If called on an empty vector, it unintentionally fills the vector with default-initialized elements.

## Changes

Replace resize by:

- Swaps the `measurementCycleQueue` with a fresh one having the desired reserved capacity only if the capacity exceeds the expected capacity.
- Otherwise, simply clears the vector.