### PR TITLE
Update configuration changes by callback

### DIFF
--- a/examples/OneOpenAir/OneOpenAir.ino
+++ b/examples/OneOpenAir/OneOpenAir.ino
@@ -370,6 +370,12 @@ void loop() {
 
   /** factory reset handle */
   factoryConfigReset();
+
+  if (configuration.isCommandRequested()) {
+    // Each state machine already has an independent request command check
+    stateMachine.executeCo2Calibration();
+    stateMachine.executeLedBarTest();
+  }
 }
 
 static void co2Update(void) {
@@ -1082,10 +1088,6 @@ static void configUpdateHandle() {
     return;
   }
 
-  if (configuration.isCo2CalibrationRequested()) {
-    stateMachine.executeCo2Calibration();
-  }
-
   String mqttUri = configuration.getMqttBrokerUri();
   if (mqttClient.isCurrentUri(mqttUri) == false) {
     mqttClient.end();
@@ -1157,11 +1159,6 @@ static void configUpdateHandle() {
     if (configuration.isDisplayBrightnessChanged()) {
       oledDisplay.setBrightness(configuration.getDisplayBrightness());
     }
-
-    stateMachine.executeLedBarTest();
-  }
-  else if(ag->isOpenAir()) {
-    stateMachine.executeLedBarTest();
   }
 
   // Update display and led bar notification based on updated configuration

--- a/examples/OneOpenAir/OneOpenAir.ino
+++ b/examples/OneOpenAir/OneOpenAir.ino
@@ -193,6 +193,7 @@ void setup() {
 
   /** Initialize local configure */
   configuration.begin();
+  configuration.setConfigurationUpdatedCallback(configUpdateHandle);
 
   /** Init I2C */
   Wire.begin(I2C_SDA_PIN, I2C_SCL_PIN);
@@ -369,9 +370,6 @@ void loop() {
 
   /** factory reset handle */
   factoryConfigReset();
-
-  /** check that local configuration changed then do some action */
-  configUpdateHandle();
 }
 
 static void co2Update(void) {
@@ -1074,8 +1072,8 @@ static void configurationUpdateSchedule(void) {
   }
 
   std::string config = agClient->httpFetchConfig();
-  if (agClient->isLastFetchConfigSucceed() && configuration.parse(config.c_str(), false)) {
-    configUpdateHandle();
+  if (agClient->isLastFetchConfigSucceed()) {
+    configuration.parse(config.c_str(), false);
   }
 }
 
@@ -1084,7 +1082,9 @@ static void configUpdateHandle() {
     return;
   }
 
-  stateMachine.executeCo2Calibration();
+  if (configuration.isCo2CalibrationRequested()) {
+    stateMachine.executeCo2Calibration();
+  }
 
   String mqttUri = configuration.getMqttBrokerUri();
   if (mqttClient.isCurrentUri(mqttUri) == false) {

--- a/src/AgConfigure.cpp
+++ b/src/AgConfigure.cpp
@@ -456,6 +456,10 @@ bool Configuration::begin(void) {
   return true;
 }
 
+void Configuration::setConfigurationUpdatedCallback(ConfigurationUpdatedCallback_t callback) {
+  _callback = callback;
+}
+
 /**
  * @brief Parse JSON configura string to local configure
  *
@@ -955,6 +959,7 @@ bool Configuration::parse(String data, bool isLocal) {
     updated = true;
     saveConfig();
     printConfig();
+    _callback();
   } else {
     if (ledBarTestRequested || co2CalibrationRequested) {
       updated = true;

--- a/src/AgConfigure.cpp
+++ b/src/AgConfigure.cpp
@@ -955,16 +955,18 @@ bool Configuration::parse(String data, bool isLocal) {
     changed = true;
   }
 
+  if (ledBarTestRequested || co2CalibrationRequested) {
+    commandRequested = true;
+    updated = true;
+  }
+
   if (changed) {
     updated = true;
     saveConfig();
     printConfig();
     _callback();
-  } else {
-    if (ledBarTestRequested || co2CalibrationRequested) {
-      updated = true;
-    }
   }
+
   return true;
 }
 
@@ -1162,6 +1164,12 @@ bool Configuration::isUpdated(void) {
   bool updated = this->updated;
   this->updated = false;
   return updated;
+}
+
+bool Configuration::isCommandRequested(void) {
+  bool oldState = this->commandRequested;
+  this->commandRequested = false;
+  return oldState;
 }
 
 String Configuration::jsonTypeInvalidMessage(String name, String type) {

--- a/src/AgConfigure.h
+++ b/src/AgConfigure.h
@@ -28,6 +28,7 @@ private:
   bool co2CalibrationRequested;
   bool ledBarTestRequested;
   bool updated;
+  bool commandRequested = false;
   String failedMessage;
   bool _noxLearnOffsetChanged;
   bool _tvocLearningOffsetChanged;
@@ -93,6 +94,7 @@ public:
   void reset(void);
   String getModel(void);
   bool isUpdated(void);
+  bool isCommandRequested(void);
   String getFailedMesage(void);
   void setPostToAirGradient(bool enable);
   bool noxLearnOffsetChanged(void);

--- a/src/AgConfigure.h
+++ b/src/AgConfigure.h
@@ -70,6 +70,9 @@ public:
   bool hasSensorSGP = true;
   bool hasSensorSHT = true;
 
+  typedef void (*ConfigurationUpdatedCallback_t)();
+  void setConfigurationUpdatedCallback(ConfigurationUpdatedCallback_t callback);
+
   bool begin(void);
   bool parse(String data, bool isLocal);
   String toString(void);
@@ -116,6 +119,8 @@ public:
   PMCorrection getPMCorrection(void);
   TempHumCorrection getTempCorrection(void);
   TempHumCorrection getHumCorrection(void);
+private:
+  ConfigurationUpdatedCallback_t _callback;
 };
 
 #endif /** _AG_CONFIG_H_ */


### PR DESCRIPTION
## Issue

#322 

## Changes

Change the way OneOpenAir examples update local configuration more realtime by using callback from Configuration class if there's an update.