### PR TITLE
Post measures and fetch configuration on boot only if respective configuration is set

### DIFF
--- a/examples/OneOpenAir/OneOpenAir.ino
+++ b/examples/OneOpenAir/OneOpenAir.ino
@@ -1051,6 +1051,7 @@ void initializeNetwork() {
 
   // Skip fetch configuration if configuration control is set to "local" only
   if (configuration.getConfigurationControl() == ConfigurationControl::ConfigurationControlLocal) {
+    ledBarEnabledUpdate();
     return;
   }
 


### PR DESCRIPTION
## Problem

- On boot, first post measures still attempted even `postDataToAirGradient` is set to false
- On boot, first fetch configuration from AirGradient server still attempted even `configurationControl` is set to `local`

## Changes

Only attempt transmission on boot to AirGradient server when respective configuration is set

#### Sample logs

```
01:06:41]Reset reason: ESP_RST_UNKNOWN
[01:06:41][Configure] Info: Reading file...
[01:06:41][Configure] Info: Reading file: success
[01:06:41][Configure] Info: Parse file to JSON
[01:06:41][Configure] Info: corrections not found
[01:06:41][Configure] Info: {"country":"ID","pmStandard":"ugm3","ledBarMode":"co2","abcDays":8,"tvocLearningOffset":12,"noxLearningOffset":12,"mqttBrokerUrl":"","httpDomain":"","temperatureUnit":"c","disableCloudConnection":false,"configurationControl":"local","postDataToAirGradient":false,"ledBarBrightness":10,"displayBrightness":10,"offlineMode":false,"monitorDisplayCompensatedValues":false,"model":"I-9PSL-DE-CE"}
[01:06:42]Detected ONE_INDOOR
[01:06:42][OledDisplay] Info: begin
[01:06:42]Firmware Version: 3.3.8-3-ge780b0a-dirty
[01:06:48]LED bar brightness: 10
[01:06:48]Init SGP41 success
[01:06:48]initializing PM sensor
[01:06:48]cleared 0 byte(s)
[01:06:48]setting active mode
[01:06:48]7 byte(s) written
[01:06:49]Set S8 AbcDays successful
[01:06:52][AGSERIAL] Info: IICSerial initialized
[01:06:52][AGSERIAL] Warning: IICSerial failed open serial line, retry..
[01:06:52][AGSERIAL] Warning: IICSerial failed open serial line, retry..
[01:06:53][AGSERIAL] Warning: IICSerial failed open serial line, retry..
[01:06:53][AGSERIAL] Error: IICSerial failed open serial line, give up..
[01:06:53]Cellular module not available, using wifi
[01:06:53]*wm:AutoConnect 
[01:06:53]*wm:Connecting to SAVED AP: wifissid
[01:06:54]*wm:[ERROR] wifi begin failed 
[01:06:57]*wm:AutoConnect: SUCCESS 
[01:06:57]*wm:STA IP Address: 192.168.1.7
[01:06:57][WifiConnector] Info: Wait for configure portal
[01:06:57][WifiConnector] Info: WiFi Connected: wifissid IP: 192.168.1.7
[01:06:57][LocalServer] Info: Init: airgradient_aaaaaaaaaa.local
[01:06:57]MQTT is not configured, skipping initialization of MQTT client
[01:06:59]Display brightness: 10
[01:07:01][OTAWifi] Info: http://hw.airgradient.com/sensors/airgradient:aaaaaaaaaa/generic/os/firmware.bin?current_firmware=3.3.8-3-ge780b0a-dirty
[01:07:01]Success create networking task
[01:07:04][OTAWifi] Warning: Firmware update skipped, the server returned 400
[01:07:04]
[01:07:04]WiFi RSSI -60
[01:07:11]Last process timeout, clear buffer and last handle package
[01:07:11]PMS sensor connected 
[01:07:11]
[01:07:11]CO2 = 1084.00 ppm
[01:07:11]Temperature = 27.13 C
[01:07:11]Relative Humidity = 54.78
[01:07:11]TVOC Index = 0.0
[01:07:11]TVOC Raw = 34522.0
[01:07:11]NOx Index = 0.0
[01:07:11]NOx Raw = 17987.0
[01:07:11][1] Atmospheric PM 1.0 = 20.00 ug/m3
[01:07:11][1] Atmospheric PM 2.5 = 27.00 ug/m3
[01:07:11][1] Atmospheric PM 10 = 27.00 ug/m3
[01:07:11][1] Standard Particle PM 1.0 = 20.00 ug/m3
[01:07:11][1] Standard Particle PM 2.5 = 27.00 ug/m3
[01:07:11][1] Standard Particle PM 10 = 27.00 ug/m3
[01:07:11][1] Particle Count 0.3 = 1083.0
[01:07:11][1] Particle Count 0.5 = 950.0
[01:07:11][1] Particle Count 1.0 = 102.0
[01:07:11][1] Particle Count 2.5 = 0.0
[01:07:11][1] Particle Count 5.0 = 0.0
[01:07:11][1] Particle Count 10 = 0.0
[01:07:11]
[01:07:14]WiFi RSSI -60
```