### PR TITLE
Correct Yellow and Orange LED colors

### DIFF
--- a/src/AgStateMachine.cpp
+++ b/src/AgStateMachine.cpp
@@ -11,8 +11,8 @@
 
 #define RGB_COLOR_R 255, 0, 0   /** Red */
 #define RGB_COLOR_G 0, 255, 0   /** Green */
-#define RGB_COLOR_Y 255, 150, 0 /** Yellow */
-#define RGB_COLOR_O 255, 40, 0  /** Orange */
+#define RGB_COLOR_Y 255, 255, 0 /** Yellow */
+#define RGB_COLOR_O 255, 128, 0 /** Orange */
 #define RGB_COLOR_P 180, 0, 255 /** Purple */
 #define RGB_COLOR_CLEAR 0, 0, 0 /** No color */
 


### PR DESCRIPTION
Addresses https://github.com/airgradienthq/arduino/issues/325

The values for Orange are much more red in color and do not appear as Orange

Similarly, the values for Yellow are mostly Orange.

Set to standard values for Yellow of a full mix of Red and Green, and Orange at full Red and half Green