### PR TITLE
Link to inner docs pages from main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,18 @@ If you have an older version of the AirGradient PCB not mentioned in the example
 
 If you have any questions or problems, check out [our forum](https://forum.airgradient.com/). 
 
-## Documentation
+## Development
 
-Local server API documentation is available in [/docs/local-server.md](/docs/local-server.md) and AirGradient server API on [https://api.airgradient.com/public/docs/api/v1/](https://api.airgradient.com/public/docs/api/v1/).
+* See [compilation instructions](/docs/local-server.md) for details about how to customize AirGradient's firmware and flash it to your device.
+
+## Over the air (OTA) updates
+
+* See the [OTA Updates documentation](/docs/ota-updates.md) for details about how AirGradient monitors receive over the air updates.
+
+## API documentation
+
+* [Local server API documentation](/docs/local-server.md)
+* [AirGradient Cloud server API documentation](https://api.airgradient.com/public/docs/api/v1/).
 
 ## The following libraries have been integrated into this library for ease of use
 


### PR DESCRIPTION
Fixes #335

There's useful documentation in the docs/ directory, but it's hard for users to discover it, as there are no links to it.

This change updates the README to add links to the inner docs pages for users interested in customizing and re-flashing firmware onto their devices as well as understanding the OTA update system.