### PR TITLE
Fix JSON example in /config docs

### DIFF
--- a/docs/local-server.md
+++ b/docs/local-server.md
@@ -106,7 +106,6 @@ Compensated values apply correction algorithms to make the sensor values more ac
     "pm02": {
       "correctionAlgorithm": "epa_2021",
       "slr": {}
-      }
     }
   }
 }


### PR DESCRIPTION
The JSON example has an extra closing brace, causing the JSON to be invalid. The fix is to remove the stray closing brace.