### PR TITLE
Fix failed manual wifi reconnection call

### DIFF
--- a/src/AgWiFiConnector.cpp
+++ b/src/AgWiFiConnector.cpp
@@ -109,6 +109,7 @@ bool WifiConnector::connect(String modelName) {
   }
 
   if (WiFi.isConnected()) {
+    hasConfig = true;
     sm.handleLeds(AgStateMachineWiFiManagerStaConnected);
     return true;
   }

--- a/src/AgWiFiConnector.h
+++ b/src/AgWiFiConnector.h
@@ -55,8 +55,8 @@ private:
 
   String ssid;
   void *wifi = NULL;
-  bool hasConfig;
-  uint32_t lastRetry;
+  bool hasConfig = false;
+  uint32_t lastRetry = 0;
   bool hasPortalConfig = false;
   bool connectorTimeout = false;
   bool bleServerRunning = false;


### PR DESCRIPTION
## Changes

Set default value of `hasConfig` and set it to true if connect before provisioning flow