### PR TITLE
Supply real RH/T when calling measureRawSignals

### DIFF
--- a/src/Sgp41/Sgp41.cpp
+++ b/src/Sgp41/Sgp41.cpp
@@ -266,20 +266,17 @@ bool Sgp41::boardSupported(void) {
  * @brief Get raw signal
  *
  * @param raw_voc Raw VOC output
- * @param row_nox Raw NOx output
- * @param defaultRh
- * @param defaultT
+ * @param raw_nox Raw NOx output
  * @return true Success
  * @return false Failure
  */
-bool Sgp41::getRawSignal(uint16_t &raw_voc, uint16_t &row_nox,
-                         uint16_t defaultRh, uint16_t defaultT) {
+bool Sgp41::getRawSignal(uint16_t &raw_voc, uint16_t &raw_nox) {
   if (this->isBegin() == false) {
     return false;
   }
 
-  if (sgpSensor()->measureRawSignals(defaultRh, defaultT, raw_voc, row_nox) ==
-      0) {
+  if (sgpSensor()->measureRawSignals(this->defaultRh, this->defaultT,
+                                     raw_voc, raw_nox) == 0) {
     return true;
   }
   return false;

--- a/src/Sgp41/Sgp41.h
+++ b/src/Sgp41/Sgp41.h
@@ -66,8 +66,7 @@ private:
 #endif
   bool isBegin(void);
   bool boardSupported(void);
-  bool getRawSignal(uint16_t &raw_voc, uint16_t &raw_nox,
-                    uint16_t defaultRh = 0x8000, uint16_t defaultT = 0x6666);
+  bool getRawSignal(uint16_t &raw_voc, uint16_t &raw_nox);
   bool _noxConditioning(void);
 };
 


### PR DESCRIPTION
Feel free to ignore the PR if humidity compensation is not used on purpose. 

When looking at the code I noticed that the humidity and temperature is not sent to the SGP41, so it runs without humidity compensation. As I haven't coded C++ for long, I verified by:

```
diff --git a/src/Sgp41/Sgp41.cpp b/src/Sgp41/Sgp41.cpp
index b9716cc..f262d84 100644
--- a/src/Sgp41/Sgp41.cpp
+++ b/src/Sgp41/Sgp41.cpp
@@ -278,6 +278,11 @@ bool Sgp41::getRawSignal(uint16_t &raw_voc, uint16_t &row_nox,
     return false;
   }
 
+  Serial.print("SGP41 getRawSignal defaultRh=0x");
+  Serial.print(defaultRh, HEX);
+  Serial.print(" defaultT=0x");
+  Serial.println(defaultT, HEX);
+
   if (sgpSensor()->measureRawSignals(defaultRh, defaultT, raw_voc, row_nox) ==
       0) {
     return true;
```

Which gave the followign results in console:

SGP41 getRawSignal defaultRh=0x8000 defaultT=0x6666
SGP41 getRawSignal defaultRh=0x8000 defaultT=0x6666
SGP41 getRawSignal defaultRh=0x8000 defaultT=0x6666
SGP41 getRawSignal defaultRh=0x8000 defaultT=0x6666
SGP41 getRawSignal defaultRh=0x8000 defaultT=0x6666

No non-default values observed. After applying my fix I correctly saw values such as:

SGP41 getRawSignal defaultRh=0x9B98 defaultT=0x5F3F

Note that the spec says that humidity compensation is disabled when default values are sent.

---

I only ran my "patched" monitor for an hour or so, so can't say much about the impact. But looks good so far, the VOC index is very stable, which I would expect based on my current environment. It was so stable, I was worried it got stuck at 100 - but opening a bottle of wine next to it made it spike, and then it nicely returned to 100.