### PR TITLE
fix: include factory_calibration in PM correction algorithm matching

### DIFF
--- a/src/AgConfigure.cpp
+++ b/src/AgConfigure.cpp
@@ -116,7 +116,7 @@ PMCorrectionAlgorithm Configuration::matchPmAlgorithm(String algorithm) {
   // If the input string matches an algorithm name, return the corresponding enum value
   // Else return Unknown
 
-  const size_t enumSize = COR_ALGO_PM_SLR_FACTORY_CALIBRATION + 1;
+  const size_t enumSize = sizeof(PM_CORRECTION_ALGORITHM_NAMES) / sizeof(PM_CORRECTION_ALGORITHM_NAMES[0]);
   PMCorrectionAlgorithm result = COR_ALGO_PM_UNKNOWN;
 
   // Loop through enum values
@@ -139,12 +139,10 @@ PMCorrectionAlgorithm Configuration::matchPmAlgorithm(String algorithm) {
 }
 
 TempHumCorrectionAlgorithm Configuration::matchTempHumAlgorithm(String algorithm) {
-  // Get the actual size of the enum
-  const int enumSize = static_cast<int>(COR_ALGO_TEMP_HUM_SLR_CUSTOM);
+  const size_t enumSize = sizeof(TEMP_HUM_CORRECTION_ALGORITHM_NAMES) / sizeof(TEMP_HUM_CORRECTION_ALGORITHM_NAMES[0]);
   TempHumCorrectionAlgorithm result = COR_ALGO_TEMP_HUM_UNKNOWN;
 
-  // Loop through enum values
-  for (size_t enumVal = 0; enumVal <= enumSize; enumVal++) {
+  for (size_t enumVal = 0; enumVal < enumSize; enumVal++) {
     if (algorithm == TEMP_HUM_CORRECTION_ALGORITHM_NAMES[enumVal]) {
       result = static_cast<TempHumCorrectionAlgorithm>(enumVal);
     }

--- a/src/AgConfigure.cpp
+++ b/src/AgConfigure.cpp
@@ -116,8 +116,8 @@ PMCorrectionAlgorithm Configuration::matchPmAlgorithm(String algorithm) {
   // If the input string matches an algorithm name, return the corresponding enum value
   // Else return Unknown
 
-  const size_t enumSize = COR_ALGO_PM_SLR_CUSTOM + 1; // Get the actual size of the enum
-  PMCorrectionAlgorithm result = COR_ALGO_PM_UNKNOWN;;
+  const size_t enumSize = COR_ALGO_PM_SLR_FACTORY_CALIBRATION + 1;
+  PMCorrectionAlgorithm result = COR_ALGO_PM_UNKNOWN;
 
   // Loop through enum values
   for (size_t enumVal = 0; enumVal < enumSize; enumVal++) {


### PR DESCRIPTION
Description:                                                                                                                  
  `matchPmAlgorithm()` loop bound was hardcoded to `COR_ALGO_PM_SLR_CUSTOM + 1`,
  so it never checked index 4 (`COR_ALGO_PM_SLR_FACTORY_CALIBRATION`).                                                          
                                                                   
  Bug introduced in b374a9a (Jan 2026) — the commit added the enum value and the
  name table entry but missed updating the loop bound.

  **Impact:** devices configured with factory calibration silently got uncorrected
  PM2.5 readings.