### PR TITLE
feat: expose VOC algorithm state and allow restoring it

### DIFF
--- a/examples/BASIC/BASIC.ino
+++ b/examples/BASIC/BASIC.ino
@@ -468,6 +468,15 @@ static void configUpdateHandle() {
     }
   }
 
+  if (configuration.hasSensorSGP) {
+    if (configuration.vocAlgorithmStatesChanged()) {
+      float mean = configuration.getVocAlgorithmMean();
+      float std = configuration.getVocAlgorithmStd();
+      ag.sgp41.setVocAlgorithmStates(mean, std);
+      Serial.printf("Setting vocAlgorithmStates to mean=%.2f, std=%.2f\r\n", mean, std);
+    }
+  }
+
   if (configuration.isDisplayBrightnessChanged()) {
     oledDisplay.setBrightness(configuration.getDisplayBrightness());
   }

--- a/examples/BASIC/OpenMetrics.cpp
+++ b/examples/BASIC/OpenMetrics.cpp
@@ -158,6 +158,20 @@ String OpenMetrics::getPayload(void) {
                  "gauge");
       add_metric_point("", String(noxRaw));
     }
+
+    float vocMean, vocStd;
+    ag->sgp41.getVocAlgorithmStates(vocMean, vocStd);
+    add_metric("voc_algorithm_mean",
+               "VOC algorithm mean of the mean-variance estimator for "
+               "persisting and restoring the algorithm state across reboots",
+               "gauge");
+    add_metric_point("", String(vocMean));
+    add_metric("voc_algorithm_std",
+               "VOC algorithm standard deviation of the mean-variance "
+               "estimator for persisting and restoring the algorithm state "
+               "across reboots",
+               "gauge");
+    add_metric_point("", String(vocStd));
   }
 
   if (utils::isValidCO2(co2)) {

--- a/examples/DiyProIndoorV3_3/DiyProIndoorV3_3.ino
+++ b/examples/DiyProIndoorV3_3/DiyProIndoorV3_3.ino
@@ -520,6 +520,15 @@ static void configUpdateHandle() {
     }
   }
 
+  if (configuration.hasSensorSGP) {
+    if (configuration.vocAlgorithmStatesChanged()) {
+      float mean = configuration.getVocAlgorithmMean();
+      float std = configuration.getVocAlgorithmStd();
+      ag.sgp41.setVocAlgorithmStates(mean, std);
+      Serial.printf("Setting vocAlgorithmStates to mean=%.2f, std=%.2f\r\n", mean, std);
+    }
+  }
+
   if (configuration.isDisplayBrightnessChanged()) {
     oledDisplay.setBrightness(configuration.getDisplayBrightness());
   }

--- a/examples/DiyProIndoorV3_3/OpenMetrics.cpp
+++ b/examples/DiyProIndoorV3_3/OpenMetrics.cpp
@@ -159,6 +159,20 @@ String OpenMetrics::getPayload(void) {
                  "gauge");
       add_metric_point("", String(noxRaw));
     }
+
+    float vocMean, vocStd;
+    ag->sgp41.getVocAlgorithmStates(vocMean, vocStd);
+    add_metric("voc_algorithm_mean",
+               "VOC algorithm mean of the mean-variance estimator for "
+               "persisting and restoring the algorithm state across reboots",
+               "gauge");
+    add_metric_point("", String(vocMean));
+    add_metric("voc_algorithm_std",
+               "VOC algorithm standard deviation of the mean-variance "
+               "estimator for persisting and restoring the algorithm state "
+               "across reboots",
+               "gauge");
+    add_metric_point("", String(vocStd));
   }
 
   if (utils::isValidCO2(co2)) {

--- a/examples/DiyProIndoorV4_2/DiyProIndoorV4_2.ino
+++ b/examples/DiyProIndoorV4_2/DiyProIndoorV4_2.ino
@@ -560,6 +560,15 @@ static void configUpdateHandle() {
     }
   }
 
+  if (configuration.hasSensorSGP) {
+    if (configuration.vocAlgorithmStatesChanged()) {
+      float mean = configuration.getVocAlgorithmMean();
+      float std = configuration.getVocAlgorithmStd();
+      ag.sgp41.setVocAlgorithmStates(mean, std);
+      Serial.printf("Setting vocAlgorithmStates to mean=%.2f, std=%.2f\r\n", mean, std);
+    }
+  }
+
   if (configuration.isDisplayBrightnessChanged()) {
     oledDisplay.setBrightness(configuration.getDisplayBrightness());
   }

--- a/examples/DiyProIndoorV4_2/OpenMetrics.cpp
+++ b/examples/DiyProIndoorV4_2/OpenMetrics.cpp
@@ -158,6 +158,20 @@ String OpenMetrics::getPayload(void) {
                  "gauge");
       add_metric_point("", String(noxRaw));
     }
+
+    float vocMean, vocStd;
+    ag->sgp41.getVocAlgorithmStates(vocMean, vocStd);
+    add_metric("voc_algorithm_mean",
+               "VOC algorithm mean of the mean-variance estimator for "
+               "persisting and restoring the algorithm state across reboots",
+               "gauge");
+    add_metric_point("", String(vocMean));
+    add_metric("voc_algorithm_std",
+               "VOC algorithm standard deviation of the mean-variance "
+               "estimator for persisting and restoring the algorithm state "
+               "across reboots",
+               "gauge");
+    add_metric_point("", String(vocStd));
   }
 
   if (utils::isValidCO2(co2)) {

--- a/examples/OneOpenAir/OneOpenAir.ino
+++ b/examples/OneOpenAir/OneOpenAir.ino
@@ -1123,6 +1123,15 @@ static void configUpdateHandle() {
     }
   }
 
+  if (configuration.hasSensorSGP) {
+    if (configuration.vocAlgorithmStatesChanged()) {
+      float mean = configuration.getVocAlgorithmMean();
+      float std = configuration.getVocAlgorithmStd();
+      ag->sgp41.setVocAlgorithmStates(mean, std);
+      Serial.printf("Setting vocAlgorithmStates to mean=%.2f, std=%.2f\r\n", mean, std);
+    }
+  }
+
   if (ag->isOne()) {
     if (configuration.isLedBarBrightnessChanged()) {
       if (configuration.getLedBarBrightness() == 0) {

--- a/examples/OneOpenAir/OpenMetrics.cpp
+++ b/examples/OneOpenAir/OpenMetrics.cpp
@@ -214,6 +214,20 @@ String OpenMetrics::getPayload(void) {
                  "gauge");
       add_metric_point("", String(noxRaw));
     }
+
+    float vocMean, vocStd;
+    ag->sgp41.getVocAlgorithmStates(vocMean, vocStd);
+    add_metric("voc_algorithm_mean",
+               "VOC algorithm mean of the mean-variance estimator for "
+               "persisting and restoring the algorithm state across reboots",
+               "gauge");
+    add_metric_point("", String(vocMean));
+    add_metric("voc_algorithm_std",
+               "VOC algorithm standard deviation of the mean-variance "
+               "estimator for persisting and restoring the algorithm state "
+               "across reboots",
+               "gauge");
+    add_metric_point("", String(vocStd));
   }
 
   if (utils::isValidCO2(co2)) {

--- a/src/AgConfigure.cpp
+++ b/src/AgConfigure.cpp
@@ -64,6 +64,8 @@ JSON_PROP_DEF(atmp);
 JSON_PROP_DEF(rhum);
 JSON_PROP_DEF(extendedPmMeasures);
 JSON_PROP_DEF(satellites);
+JSON_PROP_DEF(vocAlgorithmMean);
+JSON_PROP_DEF(vocAlgorithmStd);
 
 #define jprop_model_default                           ""
 #define jprop_country_default                         "TH"
@@ -83,6 +85,8 @@ JSON_PROP_DEF(satellites);
 #define jprop_offlineMode_default                     false
 #define jprop_monitorDisplayCompensatedValues_default false
 #define jprop_extendedPmMeasures_default              false
+#define jprop_vocAlgorithmMean_default               0.0
+#define jprop_vocAlgorithmStd_default               0.0
 
 JSONVar jconfig;
 
@@ -494,6 +498,8 @@ void Configuration::defaultConfig(void) {
   jconfig[jprop_offlineMode] = jprop_offlineMode_default;
   jconfig[jprop_monitorDisplayCompensatedValues] = jprop_monitorDisplayCompensatedValues_default;
   jconfig[jprop_extendedPmMeasures] = jprop_extendedPmMeasures_default;
+  jconfig[jprop_vocAlgorithmMean] = jprop_vocAlgorithmMean_default;
+  jconfig[jprop_vocAlgorithmStd] = jprop_vocAlgorithmStd_default;
 
   // PM2.5 default correction
   pmCorrection.algorithm = COR_ALGO_PM_NONE;
@@ -821,6 +827,45 @@ bool Configuration::parse(String data, bool isLocal) {
     if (jsonTypeInvalid(root[jprop_noxLearningOffset], "number")) {
       failedMessage =
           jsonTypeInvalidMessage(String(jprop_noxLearningOffset), "number");
+      jsonInvalid();
+      return false;
+    }
+  }
+
+  _vocAlgorithmStatesChanged = false;
+  if (JSON.typeof_(root[jprop_vocAlgorithmMean]) == "number") {
+    float mean = (float)((double)root[jprop_vocAlgorithmMean]);
+    float oldMean = (float)((double)jconfig[jprop_vocAlgorithmMean]);
+    if (mean != oldMean) {
+      changed = true;
+      _vocAlgorithmStatesChanged = true;
+      configLogInfo(String(jprop_vocAlgorithmMean), String(oldMean),
+                    String(mean));
+      jconfig[jprop_vocAlgorithmMean] = (float)((double)mean);
+    }
+  } else {
+    if (jsonTypeInvalid(root[jprop_vocAlgorithmMean], "number")) {
+      failedMessage =
+          jsonTypeInvalidMessage(String(jprop_vocAlgorithmMean), "number");
+      jsonInvalid();
+      return false;
+    }
+  }
+
+  if (JSON.typeof_(root[jprop_vocAlgorithmStd]) == "number") {
+    float std = (float)((double)root[jprop_vocAlgorithmStd]);
+    float oldStd = (float)((double)jconfig[jprop_vocAlgorithmStd]);
+    if (std != oldStd) {
+      changed = true;
+      _vocAlgorithmStatesChanged = true;
+      configLogInfo(String(jprop_vocAlgorithmStd), String(oldStd),
+                    String(std));
+      jconfig[jprop_vocAlgorithmStd] = (float)((double)std);
+    }
+  } else {
+    if (jsonTypeInvalid(root[jprop_vocAlgorithmStd], "number")) {
+      failedMessage =
+          jsonTypeInvalidMessage(String(jprop_vocAlgorithmStd), "number");
       jsonInvalid();
       return false;
     }
@@ -1762,3 +1807,19 @@ bool Configuration::isSatellitesChanged(void) {
 bool Configuration::isSatellitesEnabled(void) { return _satellitesEnabled; }
 
 const String *Configuration::getSatellites() const { return _satellites; }
+
+bool Configuration::vocAlgorithmStatesChanged(void) {
+  bool changed = _vocAlgorithmStatesChanged;
+  _vocAlgorithmStatesChanged = false;
+  return changed;
+}
+
+float Configuration::getVocAlgorithmMean(void) {
+  float value = (float)((double)jconfig[jprop_vocAlgorithmMean]);
+  return value;
+}
+
+float Configuration::getVocAlgorithmStd(void) {
+  float value = (float)((double)jconfig[jprop_vocAlgorithmStd]);
+  return value;
+}

--- a/src/AgConfigure.h
+++ b/src/AgConfigure.h
@@ -34,6 +34,7 @@ private:
   String failedMessage;
   bool _noxLearnOffsetChanged;
   bool _tvocLearningOffsetChanged;
+  bool _vocAlgorithmStatesChanged = false;
   bool ledBarBrightnessChanged = false;
   bool displayBrightnessChanged = false;
   String otaNewFirmwareVersion;
@@ -109,6 +110,9 @@ public:
   bool tvocLearnOffsetChanged(void);
   int getTvocLearningOffset(void);
   int getNoxLearningOffset(void);
+  bool vocAlgorithmStatesChanged(void);
+  float getVocAlgorithmMean(void);
+  float getVocAlgorithmStd(void);
   String wifiSSID(void);
   String wifiPass(void);
   void setAirGradient(AirGradient *ag);

--- a/src/AgValue.cpp
+++ b/src/AgValue.cpp
@@ -28,6 +28,8 @@
 #define json_prop_tvocRaw "tvocRaw"
 #define json_prop_nox "noxIndex"
 #define json_prop_noxRaw "noxRaw"
+#define json_prop_vocAlgoMean "vocAlgorithmMean"
+#define json_prop_vocAlgoStd "vocAlgorithmStd"
 #define json_prop_co2 "rco2"
 
 Measurements::Measurements(Configuration &config) : config(config) {
@@ -1106,6 +1108,10 @@ String Measurements::toString(bool localServer, AgFirmwareMode fwMode, int rssi)
     if (utils::isValidNOx(_nox_raw.update.avg)) {
       root[json_prop_noxRaw] = ag->round2(_nox_raw.update.avg);
     }
+    float vocMean, vocStd;
+    ag->sgp41.getVocAlgorithmStates(vocMean, vocStd);
+    root[json_prop_vocAlgoMean] = ag->round2(vocMean);
+    root[json_prop_vocAlgoStd] = ag->round2(vocStd);
   }
 
   root["boot"] = _bootCount;

--- a/src/Sgp41/Sgp41.cpp
+++ b/src/Sgp41/Sgp41.cpp
@@ -361,5 +361,6 @@ void Sgp41::setVocAlgorithmStates(float mean, float std) {
   if (this->isBegin() == false) {
     return;
   }
+  vocAlgorithm()->reset();
   vocAlgorithm()->set_states(mean, std);
 }

--- a/src/Sgp41/Sgp41.cpp
+++ b/src/Sgp41/Sgp41.cpp
@@ -347,3 +347,19 @@ void Sgp41::setTvocLearningOffset(int offset) {
 int Sgp41::getNoxLearningOffset(void) { return noxLearnOffset; }
 
 int Sgp41::getTvocLearningOffset(void) { return tvocLearnOffset; }
+
+void Sgp41::getVocAlgorithmStates(float &mean, float &std) {
+  if (this->isBegin() == false) {
+    mean = 0;
+    std = 0;
+    return;
+  }
+  vocAlgorithm()->get_states(mean, std);
+}
+
+void Sgp41::setVocAlgorithmStates(float mean, float std) {
+  if (this->isBegin() == false) {
+    return;
+  }
+  vocAlgorithm()->set_states(mean, std);
+}

--- a/src/Sgp41/Sgp41.h
+++ b/src/Sgp41/Sgp41.h
@@ -34,6 +34,8 @@ public:
   void setTvocLearningOffset(int offset);
   int getNoxLearningOffset(void);
   int getTvocLearningOffset(void);
+  void getVocAlgorithmStates(float &mean, float &std);
+  void setVocAlgorithmStates(float mean, float std);
 
 private:
   bool onPause = false;


### PR DESCRIPTION
Expose the VOC algorithm state (mean and std) and allowing to restore them. 

It probably requires a warning somewhere to not store the state if the values are more than 10 minutes old, per the documentation of the Sensirion lib:

https://github.com/airgradienthq/arduino/blob/master/src/Libraries/Sensirion_Gas_Index_Algorithm/src/VOCGasIndexAlgorithm.h#L53-L63
>    Set previously retrieved algorithm states to resume operation after a
>    short interruption, skipping initial learning phase. This feature should
>    not be used after interruptions of more than 10 minutes. Call this once
>    after creating a new instance of GasIndexAlgorithm or calling reset() and
>    the optional set_tuning_parameters(), if desired. Otherwise, the
>    algorithm will start with initial learning phase.
>    @param state0    State0 to be restored
>    @param state1    State1 to be restored

Also, Im not sure if leaving `vocAlgorithmMean` and `vocAlgorithmStd` as separate fields is the best idea. Do you have recommendations?