### PR TITLE
OneOpenAir airgradient-client integration of new cellular registration flow

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -80,6 +80,8 @@ jobs:
             - source-path: ./
             - name: NimBLE-Arduino
               version: 2.3.7
+            - name: ArduinoJson
+              version: 7.4.3
           cli-compile-flags: |
             - --warnings
             - none

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -85,6 +85,8 @@ jobs:
           cli-compile-flags: |
             - --warnings
             - none
+            - --build-property
+            - compiler.cpp.extra_flags=-DARDUINOJSON_ENABLE_PROGMEM=0
             - --board-options
             - "${{ matrix.board_options }}"
           platforms: |

--- a/examples/OneOpenAir/OneOpenAir.ino
+++ b/examples/OneOpenAir/OneOpenAir.ino
@@ -26,6 +26,10 @@ https://forum.airgradient.com/
 CC BY-SA 4.0 Attribution-ShareAlike 4.0 International License
 
 */
+#ifndef ARDUINOJSON_ENABLE_PROGMEM
+#define ARDUINOJSON_ENABLE_PROGMEM 0
+#endif
+
 #include "AgConfigure.h"
 #include "AgSatellites.h"
 #include "AgSchedule.h"

--- a/examples/OneOpenAir/OneOpenAir.ino
+++ b/examples/OneOpenAir/OneOpenAir.ino
@@ -156,6 +156,7 @@ static void newMeasurementCycle();
 static void restartIfCeClientIssueOverTwoHours();
 static void networkSignalCheck();
 static void networkingTask(void *args);
+static AirgradientClient::PayloadType getClientPayloadType();
 
 AgSchedule dispLedSchedule(DISP_UPDATE_INTERVAL, updateDisplayAndLedBar);
 AgSchedule configSchedule(WIFI_SERVER_CONFIG_SYNC_INTERVAL, configurationUpdateSchedule);
@@ -179,9 +180,6 @@ void setup() {
   pinMode(GPIO_EXPANSION_CARD_POWER, OUTPUT);
   digitalWrite(GPIO_EXPANSION_CARD_POWER, HIGH);
 
-  /** Print device ID into log */
-  Serial.println("Serial nr: " + ag->deviceId());
-
   // Set reason why esp is reset
   esp_reset_reason_t reason = esp_reset_reason();
   measurements.setResetReason(reason);
@@ -203,6 +201,9 @@ void setup() {
     ag = new AirGradient(BoardType::OPEN_AIR_OUTDOOR);
   }
   Serial.println("Detected " + ag->getBoardName());
+
+  /** Print device ID into log */
+  Serial.println("Serial nr: " + ag->deviceId());
 
   configuration.setAirGradient(ag);
   oledDisplay.setAirGradient(ag);
@@ -957,6 +958,15 @@ static void failedHandler(String msg) {
   }
 }
 
+static AirgradientClient::PayloadType getClientPayloadType() {
+  if (!ag->isOne() &&
+      (fwMode == FW_MODE_O_1PPT || fwMode == FW_MODE_O_1PP)) {
+    return AirgradientClient::ONE_OPENAIR_TWO_PMS;
+  }
+
+  return AirgradientClient::ONE_OPENAIR;
+}
+
 void initializeNetwork() {
   // Check if cellular module available
   agSerial = new AgSerial(Wire);
@@ -989,7 +999,9 @@ void initializeNetwork() {
     delay(2500);
   }
 
-  if (!agClient->begin(ag->deviceId().c_str())) {
+  agClient->setExtendedPmMeasures(configuration.isExtendedPmMeasuresEnabled());
+
+  if (!agClient->begin(ag->deviceId().c_str(), getClientPayloadType())) {
     oledDisplay.setText("Client", "initialization", "failed");
     delay(5000);
     oledDisplay.showRebooting();
@@ -1100,6 +1112,8 @@ static void configUpdateHandle() {
     Serial.println("HTTP domain name from configuration empty, set to default");
     agClient->setHttpDomainDefault();
   }
+
+  agClient->setExtendedPmMeasures(configuration.isExtendedPmMeasuresEnabled());
 
   if (configuration.hasSensorSGP) {
     if (configuration.noxLearnOffsetChanged() || configuration.tvocLearnOffsetChanged()) {
@@ -1421,7 +1435,7 @@ void postUsingCellular(bool forcePost) {
   xSemaphoreGive(mutexMeasurementCycleQueue);
 
   // Attempt to send
-  if (agClient->httpPostMeasures(payload, extendPmMeasures) == false) {
+  if (agClient->httpPostMeasures(payload) == false) {
     // Consider network has a problem, retry in next schedule
     Serial.println("Post measures failed, retry in next schedule");
     return;

--- a/examples/OneOpenAir/OneOpenAir.ino
+++ b/examples/OneOpenAir/OneOpenAir.ino
@@ -161,6 +161,8 @@ static void restartIfCeClientIssueOverTwoHours();
 static void networkSignalCheck();
 static void networkingTask(void *args);
 static AirgradientClient::PayloadType getClientPayloadType();
+static void saveOperatorState();
+static void restoreOperatorState();
 
 AgSchedule dispLedSchedule(DISP_UPDATE_INTERVAL, updateDisplayAndLedBar);
 AgSchedule configSchedule(WIFI_SERVER_CONFIG_SYNC_INTERVAL, configurationUpdateSchedule);
@@ -963,12 +965,32 @@ static void failedHandler(String msg) {
 }
 
 static AirgradientClient::PayloadType getClientPayloadType() {
-  if (!ag->isOne() &&
-      (fwMode == FW_MODE_O_1PPT || fwMode == FW_MODE_O_1PP)) {
+  if (!ag->isOne() && (fwMode == FW_MODE_O_1PPT || fwMode == FW_MODE_O_1PP)) {
     return AirgradientClient::ONE_OPENAIR_TWO_PMS;
   }
 
   return AirgradientClient::ONE_OPENAIR;
+}
+
+static void restoreOperatorState() {
+  String ops = configuration.getCellOperators();
+  if (ops.length() == 0) {
+    Serial.println("No saved operator state to restore");
+    return;
+  }
+  uint32_t opId = configuration.getCellOperatorId();
+  if (cellularCard->setOperators(ops.c_str(), opId)) {
+    Serial.printf("Restored operator state: id=%u, list=%s\n", opId, ops.c_str());
+  } else {
+    Serial.println("Failed to restore operator state");
+  }
+}
+
+static void saveOperatorState() {
+  String ops = cellularCard->getSerializedOperators().c_str();
+  uint32_t opId = cellularCard->getCurrentOperatorId();
+  configuration.setCellOperatorState(ops, opId);
+  Serial.printf("Saved operator state: id=%u, list=%s\n", opId, ops.c_str());
 }
 
 void initializeNetwork() {
@@ -979,6 +1001,8 @@ void initializeNetwork() {
     Serial.println("Cellular module found");
     // Initialize cellular module and use cellular as agClient
     cellularCard = new CellularModuleA7672XX(agSerial, GPIO_POWER_MODULE_PIN);
+    // Restore previously saved operator state before registration
+    restoreOperatorState();
     agClient = new AirgradientCellularClient(cellularCard);
     networkOption = UseCellular;
   } else {
@@ -1012,6 +1036,11 @@ void initializeNetwork() {
     delay(2500);
     oledDisplay.setText("", "", "");
     ESP.restart();
+  }
+
+  // Save operator state after successful registration
+  if (networkOption == UseCellular) {
+    saveOperatorState();
   }
 
   // Provide openmetrics to have access to last transmission result
@@ -1662,6 +1691,7 @@ void networkingTask(void *args) {
         }
 
         // Client is ready
+        saveOperatorState();
         agCeClientProblemDetectedTime = 0; // reset to default
         agSerial->setDebug(false);         // disable at command debug
       }

--- a/platformio.ini
+++ b/platformio.ini
@@ -12,7 +12,7 @@
 platform = espressif32
 board = esp32-c3-devkitm-1
 framework = arduino
-build_flags = !echo '-D ARDUINO_USB_CDC_ON_BOOT=1 -D ARDUINO_USB_MODE=1 -D AG_LOG_LEVEL=AG_LOG_LEVEL_INFO -D GIT_VERSION=\\"'$(git describe --tags --always --dirty)'\\"'
+build_flags = !echo '-D ARDUINO_USB_CDC_ON_BOOT=1 -D ARDUINO_USB_MODE=1 -D AG_LOG_LEVEL=AG_LOG_LEVEL_INFO -D ARDUINOJSON_ENABLE_PROGMEM=0 -D GIT_VERSION=\\"'$(git describe --tags --always --dirty)'\\" -fno-exceptions'
 board_build.partitions = partitions.csv
 monitor_speed = 115200
 lib_deps =

--- a/platformio.ini
+++ b/platformio.ini
@@ -12,8 +12,7 @@
 platform = espressif32
 board = esp32-c3-devkitm-1
 framework = arduino
-; build_flags = !echo '-D ARDUINO_USB_CDC_ON_BOOT=1 -D ARDUINO_USB_MODE=1 -D AG_LOG_LEVEL=AG_LOG_LEVEL_INFO -D ARDUINOJSON_ENABLE_PROGMEM=0 -D GIT_VERSION=\\"'$(git describe --tags --always --dirty)'\\"'
-build_flags = !echo '-D ARDUINO_USB_CDC_ON_BOOT=1 -D ARDUINO_USB_MODE=1 -D AG_LOG_LEVEL=AG_LOG_LEVEL_INFO -D ARDUINOJSON_ENABLE_PROGMEM=0 -D GIT_VERSION=\"3.6.2\" -fno-exceptions'
+build_flags = !echo '-D ARDUINO_USB_CDC_ON_BOOT=1 -D ARDUINO_USB_MODE=1 -D AG_LOG_LEVEL=AG_LOG_LEVEL_INFO -D ARDUINOJSON_ENABLE_PROGMEM=0 -D GIT_VERSION=\\"'$(git describe --tags --always --dirty)'\\"'
 board_build.partitions = partitions.csv
 monitor_speed = 115200
 lib_deps =

--- a/platformio.ini
+++ b/platformio.ini
@@ -12,7 +12,8 @@
 platform = espressif32
 board = esp32-c3-devkitm-1
 framework = arduino
-build_flags = !echo '-D ARDUINO_USB_CDC_ON_BOOT=1 -D ARDUINO_USB_MODE=1 -D AG_LOG_LEVEL=AG_LOG_LEVEL_INFO -D ARDUINOJSON_ENABLE_PROGMEM=0 -D GIT_VERSION=\\"'$(git describe --tags --always --dirty)'\\" -fno-exceptions'
+; build_flags = !echo '-D ARDUINO_USB_CDC_ON_BOOT=1 -D ARDUINO_USB_MODE=1 -D AG_LOG_LEVEL=AG_LOG_LEVEL_INFO -D ARDUINOJSON_ENABLE_PROGMEM=0 -D GIT_VERSION=\\"'$(git describe --tags --always --dirty)'\\"'
+build_flags = !echo '-D ARDUINO_USB_CDC_ON_BOOT=1 -D ARDUINO_USB_MODE=1 -D AG_LOG_LEVEL=AG_LOG_LEVEL_INFO -D ARDUINOJSON_ENABLE_PROGMEM=0 -D GIT_VERSION=\"3.6.2\" -fno-exceptions'
 board_build.partitions = partitions.csv
 monitor_speed = 115200
 lib_deps =

--- a/platformio.ini
+++ b/platformio.ini
@@ -27,6 +27,7 @@ lib_deps =
 	Update
 	DNSServer
 	h2zero/NimBLE-Arduino@^2.1.0
+	bblanchon/ArduinoJson@^7
 
 [env:esp8266]
 platform = espressif8266

--- a/platformio.ini
+++ b/platformio.ini
@@ -12,7 +12,7 @@
 platform = espressif32
 board = esp32-c3-devkitm-1
 framework = arduino
-build_flags = !echo '-D ARDUINO_USB_CDC_ON_BOOT=1 -D ARDUINO_USB_MODE=1 -D AG_LOG_LEVEL=AG_LOG_LEVEL_INFO -D ARDUINOJSON_ENABLE_PROGMEM=0 -D GIT_VERSION=\\"'$(git describe --tags --always --dirty)'\\"'
+build_flags = !echo '-fno-exceptions -D ARDUINO_USB_CDC_ON_BOOT=1 -D ARDUINO_USB_MODE=1 -D AG_LOG_LEVEL=AG_LOG_LEVEL_INFO -D ARDUINOJSON_ENABLE_PROGMEM=0 -D GIT_VERSION=\\"'$(git describe --tags --always --dirty)'\\"'
 board_build.partitions = partitions.csv
 monitor_speed = 115200
 lib_deps =

--- a/src/AgConfigure.cpp
+++ b/src/AgConfigure.cpp
@@ -64,6 +64,8 @@ JSON_PROP_DEF(atmp);
 JSON_PROP_DEF(rhum);
 JSON_PROP_DEF(extendedPmMeasures);
 JSON_PROP_DEF(satellites);
+JSON_PROP_DEF(cellOperators);
+JSON_PROP_DEF(cellOperatorId);
 
 #define jprop_model_default                           ""
 #define jprop_country_default                         "TH"
@@ -83,6 +85,8 @@ JSON_PROP_DEF(satellites);
 #define jprop_offlineMode_default                     false
 #define jprop_monitorDisplayCompensatedValues_default false
 #define jprop_extendedPmMeasures_default              false
+#define jprop_cellOperators_default                   ""
+#define jprop_cellOperatorId_default                  0
 
 JSONVar jconfig;
 
@@ -494,6 +498,8 @@ void Configuration::defaultConfig(void) {
   jconfig[jprop_offlineMode] = jprop_offlineMode_default;
   jconfig[jprop_monitorDisplayCompensatedValues] = jprop_monitorDisplayCompensatedValues_default;
   jconfig[jprop_extendedPmMeasures] = jprop_extendedPmMeasures_default;
+  jconfig[jprop_cellOperators] = jprop_cellOperators_default;
+  jconfig[jprop_cellOperatorId] = jprop_cellOperatorId_default;
 
   // PM2.5 default correction
   pmCorrection.algorithm = COR_ALGO_PM_NONE;
@@ -1616,6 +1622,22 @@ void Configuration::toConfig(const char *buf) {
   /// Load correction from saved config
   updateTempHumCorrection(jconfig, rhumCorrection, jprop_rhum);
 
+  // Validate cellOperators (string)
+  if (JSON.typeof_(jconfig[jprop_cellOperators]) != "string" &&
+      JSON.typeof_(jconfig[jprop_cellOperators]) != "undefined") {
+    jconfig[jprop_cellOperators] = jprop_cellOperators_default;
+    changed = true;
+    logInfo("toConfig: cellOperators changed");
+  }
+
+  // Validate cellOperatorId (number)
+  if (JSON.typeof_(jconfig[jprop_cellOperatorId]) != "number" &&
+      JSON.typeof_(jconfig[jprop_cellOperatorId]) != "undefined") {
+    jconfig[jprop_cellOperatorId] = jprop_cellOperatorId_default;
+    changed = true;
+    logInfo("toConfig: cellOperatorId changed");
+  }
+
   if (changed) {
     saveConfig();
   }
@@ -1762,3 +1784,26 @@ bool Configuration::isSatellitesChanged(void) {
 bool Configuration::isSatellitesEnabled(void) { return _satellitesEnabled; }
 
 const String *Configuration::getSatellites() const { return _satellites; }
+
+String Configuration::getCellOperators(void) {
+  if (JSON.typeof_(jconfig[jprop_cellOperators]) != "string") {
+    return "";
+  }
+  String ops = jconfig[jprop_cellOperators];
+  return ops;
+}
+
+uint32_t Configuration::getCellOperatorId(void) {
+  if (JSON.typeof_(jconfig[jprop_cellOperatorId]) != "number") {
+    return 0;
+  }
+  uint32_t id = (uint32_t)(int)jconfig[jprop_cellOperatorId];
+  return id;
+}
+
+void Configuration::setCellOperatorState(const String &operators, uint32_t operatorId) {
+  jconfig[jprop_cellOperators] = operators;
+  jconfig[jprop_cellOperatorId] = (int)operatorId;
+  saveConfig();
+  logInfo("Cellular operator state saved");
+}

--- a/src/AgConfigure.h
+++ b/src/AgConfigure.h
@@ -132,6 +132,9 @@ public:
   bool isSatellitesChanged(void);
   bool isSatellitesEnabled(void);
   const String *getSatellites() const;
+  String getCellOperators(void);
+  uint32_t getCellOperatorId(void);
+  void setCellOperatorState(const String &operators, uint32_t operatorId);
 
 private:
   ConfigurationUpdatedCallback_t _callback;


### PR DESCRIPTION
## Summary

- Add ArduinoJson as an explicit dependency for PlatformIO and CI.
- Disable ArduinoJson PROGMEM support for OneOpenAir build compatibility.
- Disable C++ exceptions to reduce binary size.
- Update `airgradient-client` submodule to include the cellular registration-flow fixes without pulling unrelated CoAP work.
- Persists operators scan result and last successful operator to register to