### PR TITLE
Bump airgradient-client: multi-A-record DNS failover for WiFi HTTPS client

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=AirGradient Air Quality Sensor
-version=3.6.2
+version=3.6.3
 author=AirGradient <support@airgradient.com>
 maintainer=AirGradient <support@airgradient.com>
 sentence=ESP32-C3 / ESP8266 library for air quality monitor measuring PM, CO2, Temperature, TVOC and Humidity with OLED display.

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=AirGradient Air Quality Sensor
-version=3.6.3
+version=3.6.4
 author=AirGradient <support@airgradient.com>
 maintainer=AirGradient <support@airgradient.com>
 sentence=ESP32-C3 / ESP8266 library for air quality monitor measuring PM, CO2, Temperature, TVOC and Humidity with OLED display.

--- a/src/AirGradient.h
+++ b/src/AirGradient.h
@@ -15,7 +15,7 @@
 #include "Main/utils.h"
 
 #ifndef GIT_VERSION
-#define GIT_VERSION "3.6.2-snap"
+#define GIT_VERSION "3.6.3-snap"
 #endif
 
 

--- a/src/AirGradient.h
+++ b/src/AirGradient.h
@@ -15,7 +15,7 @@
 #include "Main/utils.h"
 
 #ifndef GIT_VERSION
-#define GIT_VERSION "3.6.3-snap"
+#define GIT_VERSION "3.6.4-snap"
 #endif
 
 


### PR DESCRIPTION
## Summary

Bumps the `airgradient-client` submodule to include DNS-based endpoint failover for WiFi HTTPS requests.

## What it does
- Resolves all IPv4 A records for the HTTP domain via a single raw UDP DNS query, bypassing lwIP's single-IP limitation.
- Randomly shuffles the resolved IPs at boot so devices spread naturally across backend servers.
- Each request tries every resolved IP once before falling back to standard hostname-based resolution.
- Sticks to whichever IP succeeds (sticky-per-boot); advances to the next on transport/TLS failure.
- Re-resolves DNS every hour and after exhaustion recovery.
- TLS correctness preserved: TCP connects to the selected IP but SNI, certificate validation, and Host header still use the hostname.
- Arduino-only (`#ifdef ARDUINO`). ESP-IDF path, base class API, and all callers unchanged.