### PR TITLE
Add SPS30 PM sensor support for OPEN_AIR_OUTDOOR

### DIFF
--- a/examples/OneOpenAir/OneOpenAir.ino
+++ b/examples/OneOpenAir/OneOpenAir.ino
@@ -140,7 +140,7 @@ static void configUpdateHandle(void);
 static void updateDisplayAndLedBar(void);
 static void updateTvoc(void);
 static void updatePm(void);
-static void updateSPS30(void);
+static void updateSPS30(SPS30 &sensor, int channel);
 static void sendDataToServer(void);
 static void tempHumUpdate(void);
 static void co2Update(void);
@@ -336,7 +336,7 @@ void loop() {
     co2Schedule.run();
   }
   if (configuration.hasSensorPMS1 || configuration.hasSensorPMS2 ||
-      configuration.hasSensorSPS30) {
+      configuration.hasSensorSPS30_1 || configuration.hasSensorSPS30_2) {
     pmsSchedule.run();
   }
   if (ag->isOne()) {
@@ -829,9 +829,9 @@ static void oneIndoorInit(void) {
     Serial.println("PMS5003 not found, trying SPS30...");
     configuration.hasSensorPMS1 = false;
 
-    if (ag->sps30.begin(Serial0)) {
+    if (ag->sps30_1.begin(Serial0)) {
       Serial.println("SPS30 detected on Serial0");
-      configuration.hasSensorSPS30 = true;
+      configuration.hasSensorSPS30_1 = true;
     } else {
       Serial.println("SPS30 not found either");
       dispSensorNotFound("PM sensor");
@@ -888,56 +888,100 @@ static void openAirInit(void) {
     }
   }
 
-  /** Attempt to detect PM sensors */
-  if (fwMode == FW_MODE_O_1PST) {
-    bool pmInitSuccess = false;
+  /**
+   * Attempt to detect PM sensors on available serial ports.
+   * Per-port order: PMS5003T first (@9600), fallback to SPS30 (@115200).
+   * For single-PM modes the detected sensor is always assigned to channel 1.
+   * For dual-PM modes Serial0 → channel 1, Serial1 → channel 2.
+   */
+  auto detectPmOnSerial = [](HardwareSerial &serial, PMS5003T &pms, SPS30 &sps,
+                             const char *portName) -> int {
+    // Returns: 0 = none, 1 = PMS5003T, 2 = SPS30
+    if (pms.begin(serial)) {
+      Serial.printf("Detected PMS5003T on %s\n", portName);
+      return 1;
+    }
+    Serial.printf("PMS5003T not found on %s, trying SPS30...\n", portName);
+    if (sps.begin(serial)) {
+      Serial.printf("Detected SPS30 on %s\n", portName);
+      return 2;
+    }
+    Serial.printf("No PM sensor detected on %s\n", portName);
+    return 0;
+  };
+
+  if (fwMode == FW_MODE_O_1PST || fwMode == FW_MODE_O_1PS) {
+    // Single PM channel expected — try Serial0 first, fallback Serial1
+    configuration.hasSensorPMS1 = false;
+    configuration.hasSensorPMS2 = false;
+    bool pmFound = false;
+
     if (serial0Available) {
-      if (ag->pms5003t_1.begin(Serial0) == false) {
-        configuration.hasSensorPMS1 = false;
-        Serial.println("No PM sensor detected on Serial0");
-      } else {
+      int result =
+          detectPmOnSerial(Serial0, ag->pms5003t_1, ag->sps30_1, "Serial0");
+      if (result == 1) {
+        configuration.hasSensorPMS1 = true;
         serial0Available = false;
-        pmInitSuccess = true;
-        Serial.println("Detected PM 1 on Serial0");
+        pmFound = true;
+      } else if (result == 2) {
+        configuration.hasSensorSPS30_1 = true;
+        serial0Available = false;
+        pmFound = true;
       }
     }
-    if (pmInitSuccess == false) {
-      if (serial1Available) {
-        if (ag->pms5003t_1.begin(Serial1) == false) {
-          configuration.hasSensorPMS1 = false;
-          Serial.println("No PM sensor detected on Serial1");
-        } else {
-          serial1Available = false;
-          Serial.println("Detected PM 1 on Serial1");
-        }
+    if (!pmFound && serial1Available) {
+      int result =
+          detectPmOnSerial(Serial1, ag->pms5003t_1, ag->sps30_1, "Serial1");
+      if (result == 1) {
+        configuration.hasSensorPMS1 = true;
+        serial1Available = false;
+      } else if (result == 2) {
+        configuration.hasSensorSPS30_1 = true;
+        serial1Available = false;
       }
     }
-    configuration.hasSensorPMS2 = false; // Disable PM2
   } else {
-    if (ag->pms5003t_1.begin(Serial0) == false) {
-      configuration.hasSensorPMS1 = false;
-      Serial.println("No PM sensor detected on Serial0");
-    } else {
-      Serial.println("Detected PM 1 on Serial0");
-    }
-    if (ag->pms5003t_2.begin(Serial1) == false) {
-      configuration.hasSensorPMS2 = false;
-      Serial.println("No PM sensor detected on Serial1");
-    } else {
-      Serial.println("Detected PM 2 on Serial1");
+    // Dual PM channel modes (O_1PPT / O_1PP) — Serial0 → ch1, Serial1 → ch2
+    configuration.hasSensorPMS1 = false;
+    configuration.hasSensorPMS2 = false;
+
+    // Channel 1 on Serial0
+    int result1 =
+        detectPmOnSerial(Serial0, ag->pms5003t_1, ag->sps30_1, "Serial0");
+    if (result1 == 1) {
+      configuration.hasSensorPMS1 = true;
+    } else if (result1 == 2) {
+      configuration.hasSensorSPS30_1 = true;
     }
 
+    // Channel 2 on Serial1
+    int result2 =
+        detectPmOnSerial(Serial1, ag->pms5003t_2, ag->sps30_2, "Serial1");
+    if (result2 == 1) {
+      configuration.hasSensorPMS2 = true;
+    } else if (result2 == 2) {
+      configuration.hasSensorSPS30_2 = true;
+    }
+
+    // Check if we should downgrade from two-PM to single-PM mode
     if (fwMode == FW_MODE_O_1PP) {
-      int count = (configuration.hasSensorPMS1 ? 1 : 0) + (configuration.hasSensorPMS2 ? 1 : 0);
-      if (count == 1) {
+      bool ch1HasPm =
+          configuration.hasSensorPMS1 || configuration.hasSensorSPS30_1;
+      bool ch2HasPm =
+          configuration.hasSensorPMS2 || configuration.hasSensorSPS30_2;
+      if (ch1HasPm != ch2HasPm) {
         fwMode = FW_MODE_O_1P;
       }
     }
   }
 
-  /** update the PMS poll period base on fw mode and sensor available */
-  if (fwMode != FW_MODE_O_1PST) {
-    if (configuration.hasSensorPMS1 && configuration.hasSensorPMS2) {
+  /** Update the PMS poll period based on fw mode and sensor availability */
+  if (fwMode != FW_MODE_O_1PST && fwMode != FW_MODE_O_1PS) {
+    bool ch1HasPm =
+        configuration.hasSensorPMS1 || configuration.hasSensorSPS30_1;
+    bool ch2HasPm =
+        configuration.hasSensorPMS2 || configuration.hasSensorSPS30_2;
+    if (ch1HasPm && ch2HasPm) {
       pmsSchedule.setPeriod(2000);
     }
   }
@@ -1316,52 +1360,53 @@ static void updatePMS5003() {
   }
 }
 
-static void updateSPS30(void) {
-  if (ag->sps30.readValues()) {
+static void updateSPS30(SPS30 &sensor, int channel) {
+  if (sensor.readValues()) {
     // Mass concentrations — mapped to both Ae and SP (SPS30 has no distinction)
-    measurements.update(Measurements::PM01, ag->sps30.getPm01Ae());
-    measurements.update(Measurements::PM25, ag->sps30.getPm25Ae());
-    measurements.update(Measurements::PM10, ag->sps30.getPm10Ae());
-    measurements.update(Measurements::PM01_SP, ag->sps30.getPm01Sp());
-    measurements.update(Measurements::PM25_SP, ag->sps30.getPm25Sp());
-    measurements.update(Measurements::PM10_SP, ag->sps30.getPm10Sp());
+    measurements.update(Measurements::PM01, sensor.getPm01Ae(), channel);
+    measurements.update(Measurements::PM25, sensor.getPm25Ae(), channel);
+    measurements.update(Measurements::PM10, sensor.getPm10Ae(), channel);
+    measurements.update(Measurements::PM01_SP, sensor.getPm01Sp(), channel);
+    measurements.update(Measurements::PM25_SP, sensor.getPm25Sp(), channel);
+    measurements.update(Measurements::PM10_SP, sensor.getPm10Sp(), channel);
 
     // Number concentrations (already converted to #/0.1L by wrapper)
-    measurements.update(Measurements::PM05_PC, ag->sps30.getPm05ParticleCount());
-    measurements.update(Measurements::PM01_PC, ag->sps30.getPm01ParticleCount());
-    measurements.update(Measurements::PM25_PC, ag->sps30.getPm25ParticleCount());
-    measurements.update(Measurements::PM10_PC, ag->sps30.getPm10ParticleCount());
+    measurements.update(Measurements::PM05_PC, sensor.getPm05ParticleCount(), channel);
+    measurements.update(Measurements::PM01_PC, sensor.getPm01ParticleCount(), channel);
+    measurements.update(Measurements::PM25_PC, sensor.getPm25ParticleCount(), channel);
+    measurements.update(Measurements::PM10_PC, sensor.getPm10ParticleCount(), channel);
   } else {
-    measurements.update(Measurements::PM01, utils::getInvalidPmValue());
-    measurements.update(Measurements::PM25, utils::getInvalidPmValue());
-    measurements.update(Measurements::PM10, utils::getInvalidPmValue());
-    measurements.update(Measurements::PM01_SP, utils::getInvalidPmValue());
-    measurements.update(Measurements::PM25_SP, utils::getInvalidPmValue());
-    measurements.update(Measurements::PM10_SP, utils::getInvalidPmValue());
-    measurements.update(Measurements::PM01_PC, utils::getInvalidPmValue());
-    measurements.update(Measurements::PM25_PC, utils::getInvalidPmValue());
-    measurements.update(Measurements::PM5_PC, utils::getInvalidPmValue());
-    measurements.update(Measurements::PM10_PC, utils::getInvalidPmValue());
+    measurements.update(Measurements::PM01, utils::getInvalidPmValue(), channel);
+    measurements.update(Measurements::PM25, utils::getInvalidPmValue(), channel);
+    measurements.update(Measurements::PM10, utils::getInvalidPmValue(), channel);
+    measurements.update(Measurements::PM01_SP, utils::getInvalidPmValue(), channel);
+    measurements.update(Measurements::PM25_SP, utils::getInvalidPmValue(), channel);
+    measurements.update(Measurements::PM10_SP, utils::getInvalidPmValue(), channel);
+    measurements.update(Measurements::PM01_PC, utils::getInvalidPmValue(), channel);
+    measurements.update(Measurements::PM25_PC, utils::getInvalidPmValue(), channel);
+    measurements.update(Measurements::PM5_PC, utils::getInvalidPmValue(), channel);
+    measurements.update(Measurements::PM10_PC, utils::getInvalidPmValue(), channel);
   }
 }
 
 static void updatePm(void) {
   if (ag->isOne()) {
-    if (configuration.hasSensorSPS30) {
-      updateSPS30();
+    if (configuration.hasSensorSPS30_1) {
+      updateSPS30(ag->sps30_1, 1);
     } else {
       updatePMS5003();
     }
     return;
   }
 
-  // Open Air Monitor series, can have two PMS5003T sensor
-  bool newPMS1Value = false;
-  bool newPMS2Value = false;
+  // Open Air Monitor series — each channel can be PMS5003T or SPS30.
+  // Track which channels produced valid PMS5003T T/RH for SGP41 compensation.
+  bool newPmsTempHumCh1 = false;
+  bool newPmsTempHumCh2 = false;
 
-  // Read PMS channel 1 if available
-  int channel = 1;
+  // ---- Channel 1 ----
   if (configuration.hasSensorPMS1) {
+    int channel = 1;
     if (ag->pms5003t_1.connected()) {
       measurements.update(Measurements::PM01, ag->pms5003t_1.getPm01Ae(), channel);
       measurements.update(Measurements::PM25, ag->pms5003t_1.getPm25Ae(), channel);
@@ -1375,11 +1420,8 @@ static void updatePm(void) {
       measurements.update(Measurements::PM25_PC, ag->pms5003t_1.getPm25ParticleCount(), channel);
       measurements.update(Measurements::Temperature, ag->pms5003t_1.getTemperature(), channel);
       measurements.update(Measurements::Humidity, ag->pms5003t_1.getRelativeHumidity(), channel);
-
-      // flag that new valid PMS value exists
-      newPMS1Value = true;
+      newPmsTempHumCh1 = true;
     } else {
-      // PMS channel 1 now is not connected, update using invalid value
       measurements.update(Measurements::PM01, utils::getInvalidPmValue(), channel);
       measurements.update(Measurements::PM25, utils::getInvalidPmValue(), channel);
       measurements.update(Measurements::PM10, utils::getInvalidPmValue(), channel);
@@ -1393,11 +1435,13 @@ static void updatePm(void) {
       measurements.update(Measurements::Temperature, utils::getInvalidTemperature(), channel);
       measurements.update(Measurements::Humidity, utils::getInvalidHumidity(), channel);
     }
+  } else if (configuration.hasSensorSPS30_1) {
+    updateSPS30(ag->sps30_1, 1);
   }
 
-  // Read PMS channel 2 if available
-  channel = 2;
+  // ---- Channel 2 ----
   if (configuration.hasSensorPMS2) {
+    int channel = 2;
     if (ag->pms5003t_2.connected()) {
       measurements.update(Measurements::PM01, ag->pms5003t_2.getPm01Ae(), channel);
       measurements.update(Measurements::PM25, ag->pms5003t_2.getPm25Ae(), channel);
@@ -1411,11 +1455,8 @@ static void updatePm(void) {
       measurements.update(Measurements::PM25_PC, ag->pms5003t_2.getPm25ParticleCount(), channel);
       measurements.update(Measurements::Temperature, ag->pms5003t_2.getTemperature(), channel);
       measurements.update(Measurements::Humidity, ag->pms5003t_2.getRelativeHumidity(), channel);
-
-      // flag that new valid PMS value exists
-      newPMS2Value = true;
+      newPmsTempHumCh2 = true;
     } else {
-      // PMS channel 2 now is not connected, update using invalid value
       measurements.update(Measurements::PM01, utils::getInvalidPmValue(), channel);
       measurements.update(Measurements::PM25, utils::getInvalidPmValue(), channel);
       measurements.update(Measurements::PM10, utils::getInvalidPmValue(), channel);
@@ -1429,30 +1470,32 @@ static void updatePm(void) {
       measurements.update(Measurements::Temperature, utils::getInvalidTemperature(), channel);
       measurements.update(Measurements::Humidity, utils::getInvalidHumidity(), channel);
     }
+  } else if (configuration.hasSensorSPS30_2) {
+    updateSPS30(ag->sps30_2, 2);
   }
 
+  // SGP41 compensation — only uses T/RH from PMS5003T channels (SPS30 has no T/RH)
   if (configuration.hasSensorSGP) {
-    float temp, hum;
-    if (newPMS1Value && newPMS2Value) {
-      // Both PMS has new valid value
-      temp = (measurements.getFloat(Measurements::Temperature, 1) +
-              measurements.getFloat(Measurements::Temperature, 2)) /
-             2.0f;
-      hum = (measurements.getFloat(Measurements::Humidity, 1) +
-             measurements.getFloat(Measurements::Humidity, 2)) /
-            2.0f;
-    } else if (newPMS1Value) {
-      // Only PMS1 has new valid value
-      temp = measurements.getFloat(Measurements::Temperature, 1);
-      hum = measurements.getFloat(Measurements::Humidity, 1);
-    } else {
-      // Only PMS2 has new valid value
-      temp = measurements.getFloat(Measurements::Temperature, 2);
-      hum = measurements.getFloat(Measurements::Humidity, 2);
+    if (newPmsTempHumCh1 || newPmsTempHumCh2) {
+      float temp, hum;
+      if (newPmsTempHumCh1 && newPmsTempHumCh2) {
+        temp = (measurements.getFloat(Measurements::Temperature, 1) +
+                measurements.getFloat(Measurements::Temperature, 2)) /
+               2.0f;
+        hum = (measurements.getFloat(Measurements::Humidity, 1) +
+               measurements.getFloat(Measurements::Humidity, 2)) /
+              2.0f;
+      } else if (newPmsTempHumCh1) {
+        temp = measurements.getFloat(Measurements::Temperature, 1);
+        hum = measurements.getFloat(Measurements::Humidity, 1);
+      } else {
+        temp = measurements.getFloat(Measurements::Temperature, 2);
+        hum = measurements.getFloat(Measurements::Humidity, 2);
+      }
+      ag->sgp41.setCompensationTemperatureHumidity(temp, hum);
     }
-
-    // Update compensation temperature and humidity for SGP41
-    ag->sgp41.setCompensationTemperatureHumidity(temp, hum);
+    // When no PMS5003T channel provides T/RH (e.g. 2× SPS30), SGP41 keeps
+    // its previous compensation values (default 25 °C / 50 %RH on first run).
   }
 }
 

--- a/examples/OneOpenAir/OpenMetrics.cpp
+++ b/examples/OneOpenAir/OpenMetrics.cpp
@@ -77,14 +77,28 @@ String OpenMetrics::getPayload(void) {
   int nox = utils::getInvalidNOx();
   int noxRaw = utils::getInvalidNOx();
 
+  // Convenience flags: does this channel have any PM sensor?
+  bool ch1HasPm = config.hasSensorPMS1 || config.hasSensorSPS30_1;
+  bool ch2HasPm = config.hasSensorPMS2 || config.hasSensorSPS30_2;
+
   // Get values
-  if (config.hasSensorPMS1 && config.hasSensorPMS2) {
-    _temp = (measure.getFloat(Measurements::Temperature, 1) +
-             measure.getFloat(Measurements::Temperature, 2)) /
-            2.0f;
-    _hum = (measure.getFloat(Measurements::Humidity, 1) +
-            measure.getFloat(Measurements::Humidity, 2)) /
-           2.0f;
+  if (ch1HasPm && ch2HasPm) {
+    // Two PM channels — average T/RH only from PMS5003T channels
+    if (config.hasSensorPMS1 && config.hasSensorPMS2) {
+      _temp = (measure.getFloat(Measurements::Temperature, 1) +
+               measure.getFloat(Measurements::Temperature, 2)) /
+              2.0f;
+      _hum = (measure.getFloat(Measurements::Humidity, 1) +
+              measure.getFloat(Measurements::Humidity, 2)) /
+             2.0f;
+    } else if (config.hasSensorPMS1) {
+      _temp = measure.getFloat(Measurements::Temperature, 1);
+      _hum = measure.getFloat(Measurements::Humidity, 1);
+    } else if (config.hasSensorPMS2) {
+      _temp = measure.getFloat(Measurements::Temperature, 2);
+      _hum = measure.getFloat(Measurements::Humidity, 2);
+    }
+    // PM values averaged across both channels regardless of brand
     pm01 = (measure.get(Measurements::PM01, 1) + measure.get(Measurements::PM01, 2)) / 2.0f;
     float correctedPm25_1 = measure.getCorrectedPM25(false, 1);
     float correctedPm25_2 = measure.getCorrectedPM25(false, 2);
@@ -100,7 +114,7 @@ String OpenMetrics::getPayload(void) {
         _hum = measure.getFloat(Measurements::Humidity);
       }
 
-      if (config.hasSensorPMS1) {
+      if (ch1HasPm) {
         pm01 = measure.get(Measurements::PM01);
         float correctedPm = measure.getCorrectedPM25(false, 1);
         pm25 = round(correctedPm);
@@ -108,18 +122,23 @@ String OpenMetrics::getPayload(void) {
         pm03PCount = measure.get(Measurements::PM03_PC);
       }
     } else {
-      if (config.hasSensorPMS1) {
-        _temp = measure.getFloat(Measurements::Temperature, 1);
-        _hum = measure.getFloat(Measurements::Humidity, 1);
+      // Outdoor single-channel: T/RH only from PMS5003T, PM from any sensor
+      if (ch1HasPm) {
+        if (config.hasSensorPMS1) {
+          _temp = measure.getFloat(Measurements::Temperature, 1);
+          _hum = measure.getFloat(Measurements::Humidity, 1);
+        }
         pm01 = measure.get(Measurements::PM01, 1);
         float correctedPm = measure.getCorrectedPM25(false, 1);
         pm25 = round(correctedPm);
         pm10 = measure.get(Measurements::PM10, 1);
         pm03PCount = measure.get(Measurements::PM03_PC, 1);
       }
-      if (config.hasSensorPMS2) {
-        _temp = measure.getFloat(Measurements::Temperature, 2);
-        _hum = measure.getFloat(Measurements::Humidity, 2);
+      if (ch2HasPm) {
+        if (config.hasSensorPMS2) {
+          _temp = measure.getFloat(Measurements::Temperature, 2);
+          _hum = measure.getFloat(Measurements::Humidity, 2);
+        }
         pm01 = measure.get(Measurements::PM01, 2);
         float correctedPm = measure.getCorrectedPM25(false, 2);
         pm25 = round(correctedPm);
@@ -154,7 +173,7 @@ String OpenMetrics::getPayload(void) {
   }
 
   // Add measurements that valid to the metrics
-  if (config.hasSensorPMS1 || config.hasSensorPMS2) {
+  if (ch1HasPm || ch2HasPm) {
     if (utils::isValidPm(pm01)) {
       add_metric("pm1",
                  "PM1.0 concentration as measured by the AirGradient PMS "

--- a/src/AgConfigure.h
+++ b/src/AgConfigure.h
@@ -75,8 +75,10 @@ public:
   bool hasSensorS8 = true;
   bool hasSensorPMS1 = true;
   bool hasSensorPMS2 = true;
-  bool hasSensorSPS30 =
-      false; ///< SPS30 detected as PMS alternative (auto-detect)
+  bool hasSensorSPS30_1 =
+      false; ///< SPS30 detected on PM channel 1 (auto-detect)
+  bool hasSensorSPS30_2 =
+      false; ///< SPS30 detected on PM channel 2 (auto-detect)
   bool hasSensorSGP = true;
   bool hasSensorSHT = true;
 

--- a/src/AgValue.cpp
+++ b/src/AgValue.cpp
@@ -125,7 +125,7 @@ void Measurements::printCurrentAverage() {
     }
   }
 
-  if (config.hasSensorPMS1 || config.hasSensorSPS30) {
+  if (config.hasSensorPMS1 || config.hasSensorSPS30_1) {
     printCurrentPMAverage(1);
     if (!config.hasSensorSHT) {
       if (utils::isValidTemperature(_temperature[0].update.avg)) {
@@ -140,7 +140,7 @@ void Measurements::printCurrentAverage() {
       }
     }
   }
-  if (config.hasSensorPMS2) {
+  if (config.hasSensorPMS2 || config.hasSensorSPS30_2) {
     printCurrentPMAverage(2);
     if (!config.hasSensorSHT) {
       if (utils::isValidTemperature(_temperature[1].update.avg)) {
@@ -1161,38 +1161,39 @@ String Measurements::toString(bool localServer, AgFirmwareMode fwMode, int rssi)
 
 JSONVar Measurements::buildOutdoor(bool localServer, AgFirmwareMode fwMode) {
   JSONVar outdoor;
+  bool ch1HasPm = config.hasSensorPMS1 || config.hasSensorSPS30_1;
+  bool ch2HasPm = config.hasSensorPMS2 || config.hasSensorSPS30_2;
+
   if (fwMode == FW_MODE_O_1P || fwMode == FW_MODE_O_1PS || fwMode == FW_MODE_O_1PST) {
-    // buildPMS params:
-    /// Because only have 1 PMS, allCh is set to false
-    /// But enable temp hum from PMS
-    /// compensated values if requested by local server
-    /// Set ch based on hasSensorPMSx
-    if (config.hasSensorPMS1) {
+    // Single PM channel — pick whichever channel is populated
+    // Enable temp/hum from PMS; compensated values if requested by local server
+    if (ch1HasPm) {
       outdoor = buildPMS(1, false, true, localServer);
-      if (!localServer) {
+      // Firmware version only available for PMS5003T
+      if (!localServer && config.hasSensorPMS1) {
         outdoor[json_prop_pmFirmware] =
             pms5003TFirmwareVersion(ag->pms5003t_1.getFirmwareVersion());
       }
-    } else {
+    } else if (ch2HasPm) {
       outdoor = buildPMS(2, false, true, localServer);
-      if (!localServer) {
+      if (!localServer && config.hasSensorPMS2) {
         outdoor[json_prop_pmFirmware] =
             pms5003TFirmwareVersion(ag->pms5003t_2.getFirmwareVersion());
       }
     }
   } else {
-    // FW_MODE_O_1PPT && FW_MODE_O_1PP: Outdoor monitor that have 2 PMS sensor
-    // buildPMS params:
-    /// Have 2 PMS sensor, allCh is set to true (ch params ignored)
-    /// Enable temp hum from PMS
-    /// compensated values if requested by local server
+    // FW_MODE_O_1PPT / FW_MODE_O_1PP: two PM channels, average via allCh
     outdoor = buildPMS(1, true, true, localServer);
-    // PMS5003T version
+    // Per-channel firmware version — only for PMS5003T channels
     if (!localServer) {
-      outdoor["channels"]["1"][json_prop_pmFirmware] =
-          pms5003TFirmwareVersion(ag->pms5003t_1.getFirmwareVersion());
-      outdoor["channels"]["2"][json_prop_pmFirmware] =
-          pms5003TFirmwareVersion(ag->pms5003t_2.getFirmwareVersion());
+      if (config.hasSensorPMS1) {
+        outdoor["channels"]["1"][json_prop_pmFirmware] =
+            pms5003TFirmwareVersion(ag->pms5003t_1.getFirmwareVersion());
+      }
+      if (config.hasSensorPMS2) {
+        outdoor["channels"]["2"][json_prop_pmFirmware] =
+            pms5003TFirmwareVersion(ag->pms5003t_2.getFirmwareVersion());
+      }
     }
   }
 
@@ -1202,7 +1203,7 @@ JSONVar Measurements::buildOutdoor(bool localServer, AgFirmwareMode fwMode) {
 JSONVar Measurements::buildIndoor(bool localServer) {
   JSONVar indoor;
 
-  if (config.hasSensorPMS1 || config.hasSensorSPS30) {
+  if (config.hasSensorPMS1 || config.hasSensorSPS30_1) {
     // buildPMS params:
     /// PMS channel 1 (indoor only have 1 PMS; hence allCh false)
     /// Not include temperature and humidity from PMS sensor
@@ -1210,7 +1211,8 @@ JSONVar Measurements::buildIndoor(bool localServer) {
     indoor = buildPMS(1, false, false, true);
     if (!localServer && config.hasSensorPMS1) {
       // PMS firmware version only available for PMS5003
-      indoor[json_prop_pmFirmware] = this->pms5003FirmwareVersion(ag->pms5003.getFirmwareVersion());
+      indoor[json_prop_pmFirmware] =
+          this->pms5003FirmwareVersion(ag->pms5003.getFirmwareVersion());
     }
   }
 

--- a/src/AirGradient.cpp
+++ b/src/AirGradient.cpp
@@ -6,9 +6,9 @@
 #endif
 
 AirGradient::AirGradient(BoardType type)
-    : pms5003(type), pms5003t_1(type), pms5003t_2(type), sps30(type), s8(type),
-      sgp41(type), display(type), boardType(type), button(type),
-      statusLed(type), ledBar(type), watchdog(type), sht(type) {}
+    : pms5003(type), pms5003t_1(type), pms5003t_2(type), sps30_1(type),
+      sps30_2(type), s8(type), sgp41(type), display(type), boardType(type),
+      button(type), statusLed(type), ledBar(type), watchdog(type), sht(type) {}
 
 /**
  * @brief Get pin number for I2C SDA

--- a/src/AirGradient.h
+++ b/src/AirGradient.h
@@ -82,10 +82,16 @@ public:
   PMS5003T pms5003t_2;
 
   /**
-   * @brief Sensirion SPS30 particulate matter sensor (UART).
-   * Used as alternative to PMS5003 on ONE_INDOOR via auto-detection.
+   * @brief Sensirion SPS30 particulate matter sensor (UART), channel 1.
+   * Used as alternative PM sensor via auto-detection on Serial0.
    */
-  SPS30 sps30;
+  SPS30 sps30_1;
+
+  /**
+   * @brief Sensirion SPS30 particulate matter sensor (UART), channel 2.
+   * Used on OPEN_AIR_OUTDOOR when a second SPS30 is detected.
+   */
+  SPS30 sps30_2;
 
   /**
    * @brief SenseAirS8 CO2 sensor

--- a/src/SPS30/SPS30.cpp
+++ b/src/SPS30/SPS30.cpp
@@ -17,13 +17,33 @@ bool SPS30::begin(HardwareSerial &serial) {
     return true;
   }
 
+  _bsp = getBoardDef(_boardDef);
+  if (_bsp == nullptr) {
+    AgLog("Board [%d] not supported", _boardDef);
+    return false;
+  }
+
   _serial = &serial;
 
   // Fully reset the serial port — it may have been left at 9600 baud
   // with stale buffer data from a failed PMS5003 detection attempt.
   _serial->end();
   delay(100);
-  _serial->begin(115200);
+
+  // Serial0 (UART0) defaults map to the correct PM connector pins.
+  // Serial1 shares the S8 connector pins and needs explicit GPIO mapping,
+  // same as PMS5003T::begin() does.
+#if ARDUINO_USB_CDC_ON_BOOT
+  if (_serial == &Serial0) {
+#else
+  if (_serial == &Serial) {
+#endif
+    _serial->begin(115200);
+  } else {
+    _serial->begin(115200, SERIAL_8N1, _bsp->SenseAirS8.uart_rx_pin,
+                   _bsp->SenseAirS8.uart_tx_pin);
+  }
+
   // Flush any garbage bytes left in the RX buffer
   while (_serial->available()) {
     _serial->read();

--- a/src/SPS30/SPS30.h
+++ b/src/SPS30/SPS30.h
@@ -107,6 +107,7 @@ private:
   bool _connected = false;
   int _consecutiveErrors = 0;
   BoardType _boardDef;
+  const BoardDef *_bsp = nullptr;
   SensirionUartSps30 _driver;
   HardwareSerial *_serial = nullptr;
 


### PR DESCRIPTION
Extends SPS30 support from ONE_INDOOR to OPEN_AIR_OUTDOOR.

## Supported outdoor PM configurations
- 1× SPS30
- 2× SPS30
- 1× SPS30 + 1× PMS5003T (auto-detect per serial port)

Existing 1× / 2× PMS5003T configs unchanged. SGP41 and S8 remain optional with existing behavior.

## Changes

- Rename `hasSensorSPS30` → `hasSensorSPS30_1`, add `hasSensorSPS30_2`
- Rename `sps30` → `sps30_1`, add `sps30_2` instance
- Per-port outdoor detection: PMS5003T first, SPS30 fallback
- Parameterize `updateSPS30()` by sensor ref + channel
- SGP41 T/RH compensation only from PMS5003T channels; for 2× SPS30 SGP41 keeps default 25 °C / 50 %RH
- `buildOutdoor` / OpenMetrics: PM gating broadened for SPS30; firmware version field only emitted for PMS5003T channels