### PR TITLE
feat(cellular): transmit OneOpenAir measures and config over CoAP

### DIFF
--- a/examples/OneOpenAir/OneOpenAir.ino
+++ b/examples/OneOpenAir/OneOpenAir.ino
@@ -130,7 +130,7 @@ static int lastCellSignalQuality = 99; // CSQ
 uint32_t agCeClientProblemDetectedTime = 0;
 
 SemaphoreHandle_t mutexMeasurementCycleQueue;
-static std::vector<Measurements::Measures> measurementCycleQueue;
+static std::vector<AirgradientClient::CommonPayload> measurementCycleQueue;
 
 static void boardInit(void);
 static void initializeNetwork();
@@ -162,6 +162,7 @@ static void restartIfCeClientIssueOverTwoHours();
 static void networkSignalCheck();
 static void networkingTask(void *args);
 static AirgradientClient::PayloadType getClientPayloadType();
+static AirgradientClient::CommonPayload buildCommonPayload(Measurements::Measures &mc);
 static void saveOperatorState();
 static void restoreOperatorState();
 
@@ -1024,6 +1025,57 @@ static AirgradientClient::PayloadType getClientPayloadType() {
   return AirgradientClient::ONE_OPENAIR;
 }
 
+// Map averaged sensor measures into the client CommonPayload struct. Values are
+// stored raw (the client encoder applies scaling); invalid readings use the
+// utils invalid sentinels, which the client IS_*_VALID macros treat as invalid.
+static AirgradientClient::CommonPayload buildCommonPayload(Measurements::Measures &mc) {
+  AirgradientClient::CommonPayload c;
+
+  // CO2, Temperature, Humidity
+  c.rco2 = utils::isValidCO2(mc.co2) ? static_cast<int>(mc.co2 + 0.5f) : utils::getInvalidCO2();
+  c.atmp = Measurements::avgTempHum(mc.temperature[0], mc.temperature[1],
+                                    &utils::isValidTemperature, utils::getInvalidTemperature());
+  c.rhum = Measurements::avgTempHum(mc.humidity[0], mc.humidity[1], &utils::isValidHumidity,
+                                    utils::getInvalidHumidity());
+
+  // PM mass (atmospheric environment); pm25 kept per-channel
+  c.pm01 = Measurements::avgPm(mc.pm_01[0], mc.pm_01[1]);
+  c.pm25[0] = utils::isValidPm(mc.pm_25[0]) ? mc.pm_25[0]
+                                            : static_cast<float>(utils::getInvalidPmValue());
+  c.pm25[1] = utils::isValidPm(mc.pm_25[1]) ? mc.pm_25[1]
+                                            : static_cast<float>(utils::getInvalidPmValue());
+  c.pm10 = Measurements::avgPm(mc.pm_10[0], mc.pm_10[1]);
+
+  // PM2.5 standard particle (per-channel)
+  c.pm25Sp[0] = utils::isValidPm(mc.pm_25_sp[0]) ? mc.pm_25_sp[0]
+                                                 : static_cast<float>(utils::getInvalidPmValue());
+  c.pm25Sp[1] = utils::isValidPm(mc.pm_25_sp[1]) ? mc.pm_25_sp[1]
+                                                 : static_cast<float>(utils::getInvalidPmValue());
+
+  // Particle counts; 0.3 count kept per-channel, the rest averaged
+  c.particleCount003[0] = utils::isValidPm03Count(mc.pm_03_pc[0])
+                              ? static_cast<int>(mc.pm_03_pc[0] + 0.5f)
+                              : utils::getInvalidPmValue();
+  c.particleCount003[1] = utils::isValidPm03Count(mc.pm_03_pc[1])
+                              ? static_cast<int>(mc.pm_03_pc[1] + 0.5f)
+                              : utils::getInvalidPmValue();
+  c.particleCount005 = Measurements::avgCount(mc.pm_05_pc[0], mc.pm_05_pc[1]);
+  c.particleCount01 = Measurements::avgCount(mc.pm_01_pc[0], mc.pm_01_pc[1]);
+  c.particleCount02 = Measurements::avgCount(mc.pm_25_pc[0], mc.pm_25_pc[1]);
+  c.particleCount50 = Measurements::avgCount(mc.pm_5_pc[0], mc.pm_5_pc[1]);
+  c.particleCount10 = Measurements::avgCount(mc.pm_10_pc[0], mc.pm_10_pc[1]);
+
+  // TVOC / NOx (index and raw)
+  c.tvoc = utils::isValidVOC(mc.tvoc) ? static_cast<int>(mc.tvoc + 0.5f) : utils::getInvalidVOC();
+  c.tvocRaw =
+      utils::isValidVOC(mc.tvoc_raw) ? static_cast<int>(mc.tvoc_raw + 0.5f) : utils::getInvalidVOC();
+  c.nox = utils::isValidNOx(mc.nox) ? static_cast<int>(mc.nox + 0.5f) : utils::getInvalidNOx();
+  c.noxRaw =
+      utils::isValidNOx(mc.nox_raw) ? static_cast<int>(mc.nox_raw + 0.5f) : utils::getInvalidNOx();
+
+  return c;
+}
+
 static void restoreOperatorState() {
   String ops = configuration.getCellOperators();
   if (ops.length() == 0) {
@@ -1141,7 +1193,12 @@ void initializeNetwork() {
     return;
   }
 
-  std::string config = agClient->httpFetchConfig();
+  std::string config;
+  if (networkOption == UseCellular) {
+    config = agClient->coapFetchConfig();
+  } else {
+    config = agClient->httpFetchConfig();
+  }
   configSchedule.update();
   // Check if fetch configuration failed or fetch succes but parsing failed
   if (agClient->isLastFetchConfigSucceed() == false ||
@@ -1171,7 +1228,12 @@ static void configurationUpdateSchedule(void) {
     return;
   }
 
-  std::string config = agClient->httpFetchConfig();
+  std::string config;
+  if (networkOption == UseCellular) {
+    config = agClient->coapFetchConfig();
+  } else {
+    config = agClient->httpFetchConfig();
+  }
   if (agClient->isLastFetchConfigSucceed()) {
     configuration.parse(config.c_str(), false);
   }
@@ -1539,20 +1601,20 @@ void postUsingCellular(bool forcePost) {
   }
 
   // Build payload include all measurements from queue
-  std::string payload;
-  bool extendPmMeasures = configuration.isExtendedPmMeasuresEnabled();
-  payload += std::to_string(CELLULAR_MEASUREMENT_INTERVAL / 1000); // Convert to seconds
+  AirgradientClient::AirgradientPayload payload = {};
+  payload.measureInterval = CELLULAR_MEASUREMENT_INTERVAL / 1000; // Convert to seconds
+  payload.payloadType = getClientPayloadType();
+  payload.signal = cellularCard->csqToDbm(lastCellSignalQuality); // latest signal as RSSI
+  payload.bufferCount = queueSize;
   for (int i = 0; i < queueSize; i++) {
-    auto mc = measurementCycleQueue.at(i);
-    payload += ",";
-    payload += measurements.buildMeasuresPayload(mc, extendPmMeasures);
+    payload.payloadBuffer[i].common = measurementCycleQueue.at(i);
   }
 
   // Release before actually post measures that might takes too long
   xSemaphoreGive(mutexMeasurementCycleQueue);
 
-  // Attempt to send
-  if (agClient->httpPostMeasures(payload) == false) {
+  // Attempt to send over CoAP
+  if (agClient->coapPostMeasures(payload) == false) {
     // Consider network has a problem, retry in next schedule
     Serial.println("Post measures failed, retry in next schedule");
     return;
@@ -1563,7 +1625,7 @@ void postUsingCellular(bool forcePost) {
 
   if (measurementCycleQueue.capacity() > RESERVED_MEASUREMENT_CYCLE_CAPACITY) {
     Serial.println("measurementCycleQueue capacity more than reserved space, resizing..");
-    std::vector<Measurements::Measures> tmp;
+    std::vector<AirgradientClient::CommonPayload> tmp;
     tmp.reserve(RESERVED_MEASUREMENT_CYCLE_CAPACITY);
     measurementCycleQueue.swap(tmp);
   } else {
@@ -1807,11 +1869,9 @@ void newMeasurementCycle() {
       measurementCycleQueue.erase(measurementCycleQueue.begin());
     }
 
-    // Get current measures
+    // Get current measures and cache as client payload buffer
     auto mc = measurements.getMeasures();
-    mc.signal = cellularCard->csqToDbm(lastCellSignalQuality); // convert to RSSI
-
-    measurementCycleQueue.push_back(mc);
+    measurementCycleQueue.push_back(buildCommonPayload(mc));
     Serial.println("New measurement cycle added to queue");
     // Release mutex
     xSemaphoreGive(mutexMeasurementCycleQueue);

--- a/examples/OneOpenAir/OneOpenAir.ino
+++ b/examples/OneOpenAir/OneOpenAir.ino
@@ -85,7 +85,7 @@ CC BY-SA 4.0 Attribution-ShareAlike 4.0 International License
 
 #define MEASUREMENT_TRANSMIT_CYCLE 3
 #define MAXIMUM_MEASUREMENT_CYCLE_QUEUE 80
-#define RESERVED_MEASUREMENT_CYCLE_CAPACITY 10
+#define MEASUREMENT_LOCK_TIMEOUT (3 * 60000) /** ms — cap loop() stall when a post holds the queue lock */
 
 /** I2C define */
 #define I2C_SDA_PIN 7
@@ -130,7 +130,7 @@ static int lastCellSignalQuality = 99; // CSQ
 uint32_t agCeClientProblemDetectedTime = 0;
 
 SemaphoreHandle_t mutexMeasurementCycleQueue;
-static std::vector<AirgradientClient::CommonPayload> measurementCycleQueue;
+static AirgradientClient::AirgradientPayload measurementPayload;
 
 static void boardInit(void);
 static void initializeNetwork();
@@ -284,9 +284,7 @@ void setup() {
     measurementSchedule.setPeriod(CELLULAR_MEASUREMENT_INTERVAL);
     measurementSchedule.update();
     // Queue now only applied for cellular
-    // Allocate queue memory to avoid always reallocation
-    measurementCycleQueue.reserve(RESERVED_MEASUREMENT_CYCLE_CAPACITY);
-    // Initialize mutex to access mesurementCycleQueue
+    // Initialize mutex to access measurementPayload
     mutexMeasurementCycleQueue = xSemaphoreCreateMutex();
   }
 
@@ -1581,11 +1579,13 @@ void postUsingWifi() {
  * forcePost to force post without checking transmit cycle
  */
 void postUsingCellular(bool forcePost) {
-  // Aquire queue mutex to get queue size
+  // Aquire queue mutex; held across the post so newMeasurementCycle cannot
+  // mutate the payload mid-encode. newMeasurementCycle uses a bounded take so
+  // loop() never stalls past the external watchdog.
   xSemaphoreTake(mutexMeasurementCycleQueue, portMAX_DELAY);
 
   // Make sure measurement cycle available
-  int queueSize = measurementCycleQueue.size();
+  int queueSize = measurementPayload.bufferCount;
   if (queueSize == 0) {
     Serial.println("Skipping transmission, measurementCycle empty");
     xSemaphoreGive(mutexMeasurementCycleQueue);
@@ -1600,39 +1600,21 @@ void postUsingCellular(bool forcePost) {
     return;
   }
 
-  // Build payload include all measurements from queue
-  AirgradientClient::AirgradientPayload payload = {};
-  payload.measureInterval = CELLULAR_MEASUREMENT_INTERVAL / 1000; // Convert to seconds
-  payload.payloadType = getClientPayloadType();
-  payload.signal = cellularCard->csqToDbm(lastCellSignalQuality); // latest signal as RSSI
-  payload.bufferCount = queueSize;
-  for (int i = 0; i < queueSize; i++) {
-    payload.payloadBuffer[i].common = measurementCycleQueue.at(i);
-  }
-
-  // Release before actually post measures that might takes too long
-  xSemaphoreGive(mutexMeasurementCycleQueue);
+  // Buffers and bufferCount already populated by newMeasurementCycle; set header
+  measurementPayload.measureInterval = CELLULAR_MEASUREMENT_INTERVAL / 1000; // Convert to seconds
+  measurementPayload.payloadType = getClientPayloadType();
+  measurementPayload.signal = cellularCard->csqToDbm(lastCellSignalQuality); // latest signal as RSSI
 
   // Attempt to send over CoAP
-  if (agClient->coapPostMeasures(payload) == false) {
-    // Consider network has a problem, retry in next schedule
+  if (agClient->coapPostMeasures(measurementPayload) == false) {
+    // Consider network has a problem, retry in next schedule (data retained)
     Serial.println("Post measures failed, retry in next schedule");
+    xSemaphoreGive(mutexMeasurementCycleQueue);
     return;
   }
 
-  // Post success, remove the data that previously sent from queue
-  xSemaphoreTake(mutexMeasurementCycleQueue, portMAX_DELAY);
-
-  if (measurementCycleQueue.capacity() > RESERVED_MEASUREMENT_CYCLE_CAPACITY) {
-    Serial.println("measurementCycleQueue capacity more than reserved space, resizing..");
-    std::vector<AirgradientClient::CommonPayload> tmp;
-    tmp.reserve(RESERVED_MEASUREMENT_CYCLE_CAPACITY);
-    measurementCycleQueue.swap(tmp);
-  } else {
-    // If not more than the capacity, then just clear all the values
-    measurementCycleQueue.clear();
-  }
-
+  // Post success, clear the cache
+  measurementPayload.bufferCount = 0;
   xSemaphoreGive(mutexMeasurementCycleQueue);
 }
 
@@ -1862,20 +1844,27 @@ void networkingTask(void *args) {
 }
 
 void newMeasurementCycle() {
-  if (xSemaphoreTake(mutexMeasurementCycleQueue, portMAX_DELAY) == pdTRUE) {
-    // Make sure queue not overflow
-    if (measurementCycleQueue.size() >= MAXIMUM_MEASUREMENT_CYCLE_QUEUE) {
-      // Remove the oldest data from queue if queue reach max
-      measurementCycleQueue.erase(measurementCycleQueue.begin());
-    }
-
-    // Get current measures and cache as client payload buffer
-    auto mc = measurements.getMeasures();
-    measurementCycleQueue.push_back(buildCommonPayload(mc));
-    Serial.println("New measurement cycle added to queue");
-    // Release mutex
-    xSemaphoreGive(mutexMeasurementCycleQueue);
-    // Log current free heap size
-    Serial.printf("Free heap: %u\n", ESP.getFreeHeap());
+  // Bounded wait: if a post holds the lock, wait up to MEASUREMENT_LOCK_TIMEOUT.
+  // Caps loop() stall under the external watchdog; on timeout, skip this cycle.
+  if (xSemaphoreTake(mutexMeasurementCycleQueue, pdMS_TO_TICKS(MEASUREMENT_LOCK_TIMEOUT)) != pdTRUE) {
+    Serial.println("Skip measurement cycle, transmission holding the lock");
+    return;
   }
+
+  // Make sure buffer not overflow; drop the oldest entry if at capacity
+  if (measurementPayload.bufferCount >= MAXIMUM_MEASUREMENT_CYCLE_QUEUE) {
+    memmove(&measurementPayload.payloadBuffer[0], &measurementPayload.payloadBuffer[1],
+            (MAXIMUM_MEASUREMENT_CYCLE_QUEUE - 1) * sizeof(AirgradientClient::PayloadBuffer));
+    measurementPayload.bufferCount = MAXIMUM_MEASUREMENT_CYCLE_QUEUE - 1;
+  }
+
+  // Get current measures and cache as client payload buffer
+  auto mc = measurements.getMeasures();
+  measurementPayload.payloadBuffer[measurementPayload.bufferCount].common = buildCommonPayload(mc);
+  measurementPayload.bufferCount++;
+  Serial.println("New measurement cycle added to queue");
+
+  xSemaphoreGive(mutexMeasurementCycleQueue);
+  // Log current free heap size
+  Serial.printf("Free heap: %u\n", ESP.getFreeHeap());
 }

--- a/src/AgValue.cpp
+++ b/src/AgValue.cpp
@@ -906,176 +906,46 @@ Measurements::Measures Measurements::getMeasures() {
   return mc;
 }
 
-std::string Measurements::buildMeasuresPayload(Measures &mc, bool extendedPmMeasures) {
-  std::ostringstream oss;
-
-  // CO2
-  if (utils::isValidCO2(mc.co2)) {
-    oss << std::round(mc.co2);
+float Measurements::avgTempHum(float a, float b, bool (*isValid)(float), float invalid) {
+  bool va = isValid(a), vb = isValid(b);
+  if (va && vb) {
+    return (a + b) / 2.0f;
   }
-
-  oss << ",";
-
-  // Temperature
-  if (utils::isValidTemperature(mc.temperature[0]) &&
-      utils::isValidTemperature(mc.temperature[1])) {
-    float temp = (mc.temperature[0] + mc.temperature[1]) / 2.0f;
-    oss << std::round(temp * 10);
-  } else if (utils::isValidTemperature(mc.temperature[0])) {
-    oss << std::round(mc.temperature[0] * 10);
-  } else if (utils::isValidTemperature(mc.temperature[1])) {
-    oss << std::round(mc.temperature[1] * 10);
+  if (va) {
+    return a;
   }
-
-  oss << ",";
-
-  // Humidity
-  if (utils::isValidHumidity(mc.humidity[0]) && utils::isValidHumidity(mc.humidity[1])) {
-    float hum = (mc.humidity[0] + mc.humidity[1]) / 2.0f;
-    oss << std::round(hum * 10);
-  } else if (utils::isValidHumidity(mc.humidity[0])) {
-    oss << std::round(mc.humidity[0] * 10);
-  } else if (utils::isValidHumidity(mc.humidity[1])) {
-    oss << std::round(mc.humidity[1] * 10);
+  if (vb) {
+    return b;
   }
+  return invalid;
+}
 
-  oss << ",";
-
-  /// PM1.0 atmospheric environment
-  if (utils::isValidPm(mc.pm_01[0]) && utils::isValidPm(mc.pm_01[1])) {
-    float pm01 = (mc.pm_01[0] + mc.pm_01[1]) / 2.0f;
-    oss << std::round(pm01 * 10);
-  } else if (utils::isValidPm(mc.pm_01[0])) {
-    oss << std::round(mc.pm_01[0] * 10);
-  } else if (utils::isValidPm(mc.pm_01[1])) {
-    oss << std::round(mc.pm_01[1] * 10);
+float Measurements::avgPm(float a, float b) {
+  bool va = utils::isValidPm(a), vb = utils::isValidPm(b);
+  if (va && vb) {
+    return (a + b) / 2.0f;
   }
-
-  oss << ",";
-
-  /// PM2.5 atmospheric environment
-  if (utils::isValidPm(mc.pm_25[0]) && utils::isValidPm(mc.pm_25[1])) {
-    float pm25 = (mc.pm_25[0] + mc.pm_25[1]) / 2.0f;
-    oss << std::round(pm25 * 10);
-  } else if (utils::isValidPm(mc.pm_25[0])) {
-    oss << std::round(mc.pm_25[0] * 10);
-  } else if (utils::isValidPm(mc.pm_25[1])) {
-    oss << std::round(mc.pm_25[1] * 10);
+  if (va) {
+    return a;
   }
-
-  oss << ",";
-
-  /// PM10 atmospheric environment
-  if (utils::isValidPm(mc.pm_10[0]) && utils::isValidPm(mc.pm_10[1])) {
-    float pm10 = (mc.pm_10[0] + mc.pm_10[1]) / 2.0f;
-    oss << std::round(pm10 * 10);
-  } else if (utils::isValidPm(mc.pm_10[0])) {
-    oss << std::round(mc.pm_10[0] * 10);
-  } else if (utils::isValidPm(mc.pm_10[1])) {
-    oss << std::round(mc.pm_10[1] * 10);
+  if (vb) {
+    return b;
   }
+  return static_cast<float>(utils::getInvalidPmValue());
+}
 
-  oss << ",";
-
-  // TVOC
-  if (utils::isValidVOC(mc.tvoc)) {
-    oss << std::round(mc.tvoc);
+int Measurements::avgCount(float a, float b) {
+  bool va = utils::isValidPm03Count(a), vb = utils::isValidPm03Count(b);
+  if (va && vb) {
+    return static_cast<int>(((a + b) / 2.0f) + 0.5f);
   }
-
-  oss << ",";
-
-  // NOx
-  if (utils::isValidNOx(mc.nox)) {
-    oss << std::round(mc.nox);
+  if (va) {
+    return static_cast<int>(a + 0.5f);
   }
-
-  oss << ",";
-
-  /// PM 0.3 particle count
-  if (utils::isValidPm03Count(mc.pm_03_pc[0]) && utils::isValidPm03Count(mc.pm_03_pc[1])) {
-    oss << std::round((mc.pm_03_pc[0] + mc.pm_03_pc[1]) / 2.0f);
-  } else if (utils::isValidPm03Count(mc.pm_03_pc[0])) {
-    oss << std::round(mc.pm_03_pc[0]);
-  } else if (utils::isValidPm03Count(mc.pm_03_pc[1])) {
-    oss << std::round(mc.pm_03_pc[1]);
+  if (vb) {
+    return static_cast<int>(b + 0.5f);
   }
-
-  oss << ",";
-
-  if (mc.signal < 0) {
-    oss << mc.signal;
-  }
-
-  if (extendedPmMeasures) {
-    oss << ",,,,,,,,"; // Add placeholder for MAX payload (BMS & O3/NO2)
-
-    /// PM 0.5 particle count
-    if (utils::isValidPm03Count(mc.pm_05_pc[0]) && utils::isValidPm03Count(mc.pm_05_pc[1])) {
-      oss << std::round((mc.pm_05_pc[0] + mc.pm_05_pc[1]) / 2.0f);
-    } else if (utils::isValidPm03Count(mc.pm_05_pc[0])) {
-      oss << std::round(mc.pm_05_pc[0]);
-    } else if (utils::isValidPm03Count(mc.pm_05_pc[1])) {
-      oss << std::round(mc.pm_05_pc[1]);
-    }
-
-    oss << ",";
-
-    /// PM 1.0 particle count
-    if (utils::isValidPm03Count(mc.pm_01_pc[0]) && utils::isValidPm03Count(mc.pm_01_pc[1])) {
-      oss << std::round((mc.pm_01_pc[0] + mc.pm_01_pc[1]) / 2.0f);
-    } else if (utils::isValidPm03Count(mc.pm_01_pc[0])) {
-      oss << std::round(mc.pm_01_pc[0]);
-    } else if (utils::isValidPm03Count(mc.pm_01_pc[1])) {
-      oss << std::round(mc.pm_01_pc[1]);
-    }
-
-    oss << ",";
-
-    /// PM 2.5 particle count
-    if (utils::isValidPm03Count(mc.pm_25_pc[0]) && utils::isValidPm03Count(mc.pm_25_pc[1])) {
-      oss << std::round((mc.pm_25_pc[0] + mc.pm_25_pc[1]) / 2.0f);
-    } else if (utils::isValidPm03Count(mc.pm_25_pc[0])) {
-      oss << std::round(mc.pm_25_pc[0]);
-    } else if (utils::isValidPm03Count(mc.pm_25_pc[1])) {
-      oss << std::round(mc.pm_25_pc[1]);
-    }
-
-    oss << ",";
-
-    /// PM 5.0 particle count
-    if (utils::isValidPm03Count(mc.pm_5_pc[0]) && utils::isValidPm03Count(mc.pm_5_pc[1])) {
-      oss << std::round((mc.pm_5_pc[0] + mc.pm_5_pc[1]) / 2.0f);
-    } else if (utils::isValidPm03Count(mc.pm_5_pc[0])) {
-      oss << std::round(mc.pm_5_pc[0]);
-    } else if (utils::isValidPm03Count(mc.pm_5_pc[1])) {
-      oss << std::round(mc.pm_5_pc[1]);
-    }
-
-    oss << ",";
-
-    /// PM 10 particle count
-    if (utils::isValidPm03Count(mc.pm_10_pc[0]) && utils::isValidPm03Count(mc.pm_10_pc[1])) {
-      oss << std::round((mc.pm_10_pc[0] + mc.pm_10_pc[1]) / 2.0f);
-    } else if (utils::isValidPm03Count(mc.pm_10_pc[0])) {
-      oss << std::round(mc.pm_10_pc[0]);
-    } else if (utils::isValidPm03Count(mc.pm_10_pc[1])) {
-      oss << std::round(mc.pm_10_pc[1]);
-    }
-
-    oss << ",";
-
-    /// PM2.5 standard particle
-    if (utils::isValidPm(mc.pm_25_sp[0]) && utils::isValidPm(mc.pm_25_sp[1])) {
-      float pm10 = (mc.pm_25_sp[0] + mc.pm_25_sp[1]) / 2.0f;
-      oss << std::round(pm10 * 10);
-    } else if (utils::isValidPm(mc.pm_25_sp[0])) {
-      oss << std::round(mc.pm_25_sp[0] * 10);
-    } else if (utils::isValidPm(mc.pm_25_sp[1])) {
-      oss << std::round(mc.pm_25_sp[1] * 10);
-    }
-  }
-
-  return oss.str();
+  return utils::getInvalidPmValue();
 }
 
 String Measurements::toString(bool localServer, AgFirmwareMode fwMode, int rssi) {

--- a/src/AgValue.h
+++ b/src/AgValue.h
@@ -189,7 +189,15 @@ public:
 
   Measures getMeasures();
 
-  std::string buildMeasuresPayload(Measures &mc, bool extendedPmMeasures);
+  /**
+   * @brief Average two channels that respect per-value validity
+   *
+   * Returns the average when both channels are valid, the single valid channel
+   * when only one is valid, or the provided invalid sentinel when neither is.
+   */
+  static float avgTempHum(float a, float b, bool (*isValid)(float), float invalid);
+  static float avgPm(float a, float b);
+  static int avgCount(float a, float b);
 
   /**
    * Set to true if want to debug every update value

--- a/vhub/OneOpenAir.vhub.json
+++ b/vhub/OneOpenAir.vhub.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "rev": "90e8569-wip",
+  "rev": "7c00651-wip",
   "product": {
     "slug": "one-open-air",
     "name": "ONE Indoor & Open Air",
@@ -152,7 +152,7 @@
       "applies_to": ["ONE_INDOOR"],
       "description": "If httpDomain is configured, OLED indicates a custom server target during boot",
       "expected_result": "When httpDomain is non-empty in config, OLED shows the three-line message \"HTTP domain name\" / \"using local\" / \"configuration\" and serial log prints \"HTTP domain name is set to: <domain>\". When empty/unset, no custom-domain OLED message is shown.",
-      "notes": "Requires: OLED + serial log. Set httpDomain via /config PUT or cloud, then reboot."
+      "notes": "Requires: OLED + serial log. Set httpDomain via /config PUT or cloud, then reboot. Note: on cellular, httpDomain does not redirect measures/config (those use CoAP to a fixed host); the OLED message still appears."
     },
     {
       "id": "boot.network-options.auto-select",
@@ -178,8 +178,8 @@
       "sub_category": "First server communication",
       "applies_to": ["ONE_INDOOR", "OPEN_AIR_OUTDOOR"],
       "description": "After network is up at boot, device fetches configuration from server",
-      "expected_result": "Serial log shows GET to /sensors/airgradient:<serial>/one/config with response 200 when registered or 400 when not registered. Configuration values are applied to runtime state when fetch and parse succeed.",
-      "notes": "Requires: serial log + working network. Must complete before runtime begins."
+      "expected_result": "On WiFi, serial log shows an HTTPS GET to /sensors/airgradient:<serial>/one/config with response 200 when registered or 400 when not registered. On cellular, the fetch goes over CoAP (log \"CoAP fetch configuration from <host>:5683\" then \"CoAP request successful\"); a not-registered device is surfaced via the CoAP response code rather than HTTP 400. Configuration values are applied to runtime state when fetch and parse succeed.",
+      "notes": "Requires: serial log + working network. Must complete before runtime begins. Cellular uses CoAP (coapFetchConfig); WiFi uses HTTPS (httpFetchConfig)."
     },
     {
       "id": "boot.first-server-comm.boot-post-wifi",
@@ -196,8 +196,8 @@
       "sub_category": "First server communication",
       "applies_to": ["ONE_INDOOR", "OPEN_AIR_OUTDOOR"],
       "description": "On Cellular, the boot POST is sent after a ~20s delay and carries a full measurement cycle",
-      "expected_result": "Serial log shows \"Prepare first measures cycle to send on boot for 20s\", then ~20s later \"New measurement cycle added to queue\", followed by a cellular CSV POST (interval, current measurement fields, cellular signal).",
-      "notes": "Requires: serial log + cellular network. Unlike WiFi, cellular boot POST carries a full measurement cycle, not a hello payload. Timing approximate (±5s)."
+      "expected_result": "Serial log shows \"Prepare first measures cycle to send on boot for 20s\", then ~20s later \"New measurement cycle added to queue\", followed by a binary CoAP post of the measurement cycle (coapPostMeasures to coap.airgradient.com / IP:5683).",
+      "notes": "Requires: serial log + cellular network. Unlike WiFi, cellular boot POST carries a full measurement cycle as a binary CoAP payload, not a hello payload. Timing approximate (±5s)."
     },
     {
       "id": "boot.first-server-comm.ota-check",
@@ -839,13 +839,22 @@
       "notes": "Requires: serial log + MQTT broker reachable from the device's LAN. MQTT is not available for cellular (log: \"MQTT not available for cellular options\")."
     },
     {
+      "id": "server-comm.wifi.dns-multi-a-record-failover",
+      "category": "AG Server Communication",
+      "sub_category": "WiFi transmission",
+      "applies_to": ["ONE_INDOOR", "OPEN_AIR_OUTDOOR"],
+      "description": "On WiFi, HTTPS requests fail over across multiple DNS A records before falling back to the hostname",
+      "expected_result": "For HTTPS fetch-config / post-measures, the WiFi client resolves all IPv4 A records for the server host via a single raw UDP DNS query, shuffles them, and sticks to one IP while it works (log \"TLS up to <ip>\"). On transport/TLS failure it advances to the next IP; after every IP fails it falls back to a hostname-based connection (log \"All N IP(s) failed; falling back to hostname resolution\") and refreshes the IP list on success. TLS SNI and certificate verification always use the hostname, even when connecting to an IP.",
+      "notes": "Requires: serial log + a server host with multiple A records, plus the ability to blackhole specific IPs (e.g. firewall rules) to force per-IP failures. Arduino/WiFi path only; cellular is unaffected."
+    },
+    {
       "id": "server-comm.cellular.measurement-cycle-3min",
       "category": "AG Server Communication",
       "sub_category": "Cellular transmission",
       "applies_to": ["ONE_INDOOR", "OPEN_AIR_OUTDOOR"],
       "description": "On cellular, a measurement cycle is captured every 3 minutes and added to the queue",
-      "expected_result": "Serial log shows \"New measurement cycle added to queue\" every 3 minutes (CELLULAR_MEASUREMENT_INTERVAL = 180000 ms). Each cycle captures the current sensor values plus the cellular signal strength converted to RSSI via csqToDbm().",
-      "notes": "Requires: serial log + cellular network. The queue accumulates cycles until the transmission condition is met."
+      "expected_result": "Serial log shows \"New measurement cycle added to queue\" every 3 minutes (CELLULAR_MEASUREMENT_INTERVAL = 180000 ms). Each cycle captures the current sensor values into the cached payload buffer. The cellular signal is not stored per cycle; it is applied once (latest csqToDbm value) when the batch is posted.",
+      "notes": "Requires: serial log + cellular network. The payload buffer accumulates cycles (cap 80, oldest dropped when full) until the transmission condition is met."
     },
     {
       "id": "server-comm.cellular.post-when-queue-divisible-by-3",
@@ -853,7 +862,7 @@
       "sub_category": "Cellular transmission",
       "applies_to": ["ONE_INDOOR", "OPEN_AIR_OUTDOOR"],
       "description": "On cellular, measures are posted when the queue size is divisible by 3",
-      "expected_result": "The transmission schedule runs every 3 minutes (CELLULAR_TRANSMISSION_INTERVAL). On each run, postUsingCellular checks if measurementCycleQueue.size() % 3 == 0. If not, log \"Not ready to transmit, queue size are <N>\". If divisible, a CSV payload is built from all queued cycles (interval in seconds + per-cycle fields) and POSTed. On success, the queue is cleared.",
+      "expected_result": "The transmission schedule runs every 3 minutes (CELLULAR_TRANSMISSION_INTERVAL). On each run, postUsingCellular checks if the buffered cycle count % 3 == 0. If not, log \"Not ready to transmit, queue size are <N>\". If divisible, a binary AirgradientPayload is built from all buffered cycles (measure interval + per-cycle fields + latest signal) and sent via CoAP (coapPostMeasures). On success, the buffer is cleared (bufferCount reset to 0).",
       "notes": "Requires: serial log + cellular. Because measurement and transmission intervals are both 3 min, the queue typically hits size 1 at each transmission window. The divisible-by-3 condition means the first automatic transmission fires after 3 cycles (9 min), unless forcePost is used (boot POST)."
     },
     {
@@ -862,8 +871,17 @@
       "sub_category": "Cellular transmission",
       "applies_to": ["ONE_INDOOR", "OPEN_AIR_OUTDOOR"],
       "description": "On cellular, configuration is fetched from the AG server every 30 minutes",
-      "expected_result": "Serial log shows fetch-config executing on a 30-minute schedule (CELLULAR_SERVER_CONFIG_SYNC_INTERVAL = 1800000 ms). Same parsing and configurationControl checks as WiFi.",
+      "expected_result": "Serial log shows CoAP fetch-config (coapFetchConfig) executing on a 30-minute schedule (CELLULAR_SERVER_CONFIG_SYNC_INTERVAL = 1800000 ms). Same parsing and configurationControl checks as WiFi.",
       "notes": "Requires: serial log + cellular. The longer interval reduces cellular data usage."
+    },
+    {
+      "id": "server-comm.cellular.buffer-accumulate-and-flush-on-recovery",
+      "category": "AG Server Communication",
+      "sub_category": "Cellular transmission",
+      "applies_to": ["ONE_INDOOR", "OPEN_AIR_OUTDOOR"],
+      "description": "During a cellular outage, measurement cycles are cached and all are posted once connectivity recovers",
+      "expected_result": "While the cellular link is down, measurement cycles keep being captured every 3 minutes (\"New measurement cycle added to queue\") and accumulate in the cache (up to 80 cycles; the oldest is dropped once full). No successful post occurs during the outage. When connectivity is restored, the next transmission sends the entire cached batch in a single CoAP transfer (block-wise if larger than one packet) and the cache is cleared.",
+      "notes": "Requires: serial log + cellular. Reproduce by removing coverage for a few hours (e.g. pull the antenna / SIM after registration), let cycles accumulate, then restore coverage and confirm a single flush of all buffered cycles followed by an empty cache."
     },
     {
       "id": "server-comm.dashboard-values-match",
@@ -871,7 +889,7 @@
       "sub_category": "Data integrity",
       "applies_to": ["ONE_INDOOR", "OPEN_AIR_OUTDOOR"],
       "description": "Values shown on the AirGradient dashboard match the payload that was POSTed",
-      "expected_result": "For WiFi, compare the serial log PAYLOAD JSON against dashboard readings for the same POST timestamp; valid sensor fields, WiFi RSSI, and boot/bootCount should correspond, allowing for dashboard-side conversions such as AQI. For cellular, compare the posted CSV measurement-cycle payload fields against dashboard readings; cellular payload does not include bootCount.",
+      "expected_result": "For WiFi, compare the serial log PAYLOAD JSON against dashboard readings for the same POST timestamp; valid sensor fields, WiFi RSSI, and boot/bootCount should correspond, allowing for dashboard-side conversions such as AQI. For cellular, compare the posted binary CoAP measurement-cycle payload fields against dashboard readings; the cellular payload does not include bootCount.",
       "notes": "Requires: serial log + dashboard access. Best checked immediately after a POST to avoid stale-cache mismatches."
     },
     {
@@ -879,9 +897,9 @@
       "category": "AG Server Communication",
       "sub_category": "Extended payload",
       "applies_to": ["ONE_INDOOR", "OPEN_AIR_OUTDOOR"],
-      "description": "When extendedPmMeasures is enabled, extra PM fields are included in the POST payload",
-      "expected_result": "On cellular, when extendedPmMeasures=true, extra PM particle-count and standard-particle fields are appended to each CSV measurement cycle. On WiFi, extendedPmMeasures does not change measurements.toString(); JSON PM fields are included based on sensor availability/validity regardless of the flag.",
-      "notes": "Requires: serial log + extendedPmMeasures enabled in the server config. Cellular-specific: compare CSV payload with and without the flag."
+      "description": "All valid PM fields are included in the POST payload",
+      "expected_result": "On cellular, the binary CoAP payload encodes every valid PM field (particle counts and standard-particle values); whether a field is sent depends only on its validity, not on the extendedPmMeasures flag. On WiFi, measurements.toString() likewise includes JSON PM fields based on sensor availability/validity.",
+      "notes": "Requires: serial log. Field inclusion is driven purely by validity on both transports; extendedPmMeasures does not change the payload."
     },
     {
       "id": "server-comm.cloud-connection-disabled",
@@ -889,7 +907,7 @@
       "sub_category": "Suppression",
       "applies_to": ["ONE_INDOOR", "OPEN_AIR_OUTDOOR"],
       "description": "When disableCloudConnection is true, all AG server traffic is suppressed",
-      "expected_result": "With disableCloudConnection=true on WiFi, boot POST, config fetch, scheduled transmission, and OTA are skipped; local server endpoints and MQTT still function. At runtime, the networking task skips config/transmission/OTA schedules. On cellular, note current code still performs the initial boot httpFetchConfig() unless configurationControl=local; scheduled traffic is skipped afterward.",
+      "expected_result": "With disableCloudConnection=true on WiFi, boot POST, config fetch, scheduled transmission, and OTA are skipped; local server endpoints and MQTT still function. At runtime, the networking task skips config/transmission/OTA schedules. On cellular, note current code still performs the initial boot CoAP fetch-config (coapFetchConfig) unless configurationControl=local; scheduled traffic is skipped afterward.",
       "notes": "Requires: serial log + disableCloudConnection set via the WiFi portal checkbox. The flag overrides both configurationControl and postDataToAirGradient."
     },
     {
@@ -1033,8 +1051,8 @@
       "sub_category": "Server target",
       "applies_to": ["ONE_INDOOR", "OPEN_AIR_OUTDOOR"],
       "description": "Changing httpDomain redirects AG client and OTA traffic to the custom domain",
-      "expected_result": "PUT {\"httpDomain\":\"custom.example.com\"} to /config. The firmware applies agClient->setHttpDomain() and serial log shows \"HTTP domain name set to: custom.example.com\". Subsequent fetch-config, post-measures, and OTA requests target that domain. Setting to empty string reverts to the default AirGradient domain.",
-      "notes": "Requires: serial log. The domain change takes effect on the next scheduled request, not retroactively."
+      "expected_result": "PUT {\"httpDomain\":\"custom.example.com\"} to /config. The firmware applies agClient->setHttpDomain() and serial log shows \"HTTP domain name set to: custom.example.com\". On WiFi, subsequent fetch-config and post-measures target that domain; OTA targets it on both transports. On cellular, measures and config use CoAP to a fixed host and are NOT affected by httpDomain (only cellular OTA is). Setting to empty string reverts to the default AirGradient domain.",
+      "notes": "Requires: serial log. The domain change takes effect on the next scheduled request, not retroactively. There is currently no config override for the CoAP host, so a custom domain does not redirect cellular measures/config."
     },
     {
       "id": "config-effect.post-data-to-airgradient",


### PR DESCRIPTION
### Summary

Moves the OneOpenAir cellular path from HTTP/CSV to **CoAP with a binary
payload** for both posting measures and fetching configuration. Also bumps
`airgradient-client` to `main`, which brings the CoAP stack, the binary
payload encoder, and the WiFi multi-A-record DNS failover. The WiFi path is
unchanged (still HTTP).

### Changes

- **Bump `airgradient-client` → `main`**: CoAP transport + binary payload
  encoder; multi-A-record DNS failover for the WiFi HTTPS client.
- **Cellular over CoAP**: cache each cycle as a client `CommonPayload` in a
  single static `AirgradientPayload` buffer; send via `coapPostMeasures`,
  fetch config via `coapFetchConfig`.
- **Payload mapping**: replace the legacy CSV string builder with a
  `Measures → CommonPayload` mapping; move channel-averaging helpers into
  `Measurements`.
- **Concurrency/safety**: post holds the buffer lock; `newMeasurementCycle`
  uses a bounded (3 min) take so the loop never stalls past the watchdog.
- **vhub**: update the OneOpenAir QA template for the new cellular transport
  and the WiFi multi-DNS feature.

### Validation

- `pio run -e esp32-c3`: compiles & links (RAM 20.9%, Flash 89.9%).
- vhub template validated (134 tests; schema/id/variant rules pass).
- On-device: cellular CoAP **config fetch** confirmed on hardware; the boot
  **post** stack-overflow was fixed (static buffer) — re-verify steady-state
  post/flush on a cellular unit.