### PR TITLE
fix(cellular): flush measure queue when buffer full

### DIFF
--- a/examples/OneOpenAir/OneOpenAir.ino
+++ b/examples/OneOpenAir/OneOpenAir.ino
@@ -1592,9 +1592,11 @@ void postUsingCellular(bool forcePost) {
     return;
   }
 
-  // Check queue size if its ready to transmit
-  // It is ready if size is divisible by 3
-  if (!forcePost && (queueSize % MEASUREMENT_TRANSMIT_CYCLE) > 0) {
+  // Ready when size is divisible by 3, or the buffer is full. The full-buffer
+  // override breaks a deadlock: the cap pins size at a non-multiple of 3, which
+  // the divisibility gate alone would never release.
+  bool queueFull = queueSize >= MAXIMUM_MEASUREMENT_CYCLE_QUEUE;
+  if (!forcePost && !queueFull && (queueSize % MEASUREMENT_TRANSMIT_CYCLE) > 0) {
     Serial.printf("Not ready to transmit, queue size are %d\n", queueSize);
     xSemaphoreGive(mutexMeasurementCycleQueue);
     return;


### PR DESCRIPTION
### Summary

Fixes a permanent transmit deadlock on cellular. When the network stays down long enough for the measurement buffer to reach capacity, the device gets stuck logging `Not ready to transmit, queue size are 80` and never sends again — even after connectivity returns.

### Root cause

Transmission is gated on `bufferCount % MEASUREMENT_TRANSMIT_CYCLE == 0` (divisible by 3). Once the buffer caps out, the overflow guard pins `bufferCount` at `MAXIMUM_MEASUREMENT_CYCLE_QUEUE` (80), which is not a multiple of 3, so the divisibility gate can never release.

### Changes

- Add a full-buffer override in `postUsingCellular`: transmit when the queue is at capacity, regardless of divisibility. Normal 3-cycle batching is unchanged.