### PR TITLE
sgp41: do not kill poll task on conditioning failure

### DIFF
--- a/src/Sgp41/Sgp41.cpp
+++ b/src/Sgp41/Sgp41.cpp
@@ -158,7 +158,6 @@ void Sgp41::_handle(void) {
     vTaskDelay(pdMS_TO_TICKS(1000));
     if (_noxConditioning() == false) {
       AgLog("SGP on conditioning failed");
-      vTaskDelete(NULL);
     }
   }
 


### PR DESCRIPTION
`Sgp41::_handle()` calls `vTaskDelete(NULL)` if a single `executeConditioning()` I2C transaction fails during the 10 second NOx conditioning window after boot:

```cpp
for (int i = 0; i < 10; i++) {
  vTaskDelay(pdMS_TO_TICKS(1000));
  if (_noxConditioning() == false) {
    AgLog("SGP on conditioning failed");
    vTaskDelete(NULL);
  }
}
```

one transient bus glitch permanently kills the polling task:

- `onConditioning` is never cleared, so `getTvocIndex()` and `getNoxIndex()` will return invalid values until reboot. the device shows `-` for TVOC and NOx forever while everything else works.

- a later call to `Sgp41::end()` passes the now stale `pollTask` handle to `vTaskDelete()`. FreeRTOS may have reused that TCB, so this is a use after free that can crash or kill an unrelated task.

the ESP8266 conditioning path just logs the failure and continues, and the ESP32 steady state loop tolerates up to 5 consecutive read failures before invalidating values

should just log the failure and continue instead, matching the ESP8266 path which already tolerates conditioning errors, which is what this commit aims to do
