### PR TITLE
Add PlatformIO build to Action

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -103,3 +103,27 @@ jobs:
       # the resulting image (e.g. that it boots successfully and sends metrics)
       # but that would either require a high fidelity device emulator, or a
       # "hardware lab" runner that is directly connected to a relevant device.
+
+  platformio-build:
+    strategy:
+      fail-fast: false
+      matrix:
+        environment:
+          - "esp8266"
+          - "esp32-c3"
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v7.0.1
+        with:
+          fetch-depth: 0
+          submodules: 'true'
+
+      - uses: actions/setup-python@v5.4.0
+        with:
+          python-version: '3.x'
+
+      - name: Install PlatformIO
+        run: pip install platformio
+
+      - name: Build with PlatformIO
+        run: pio run --environment ${{ matrix.environment }}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,20 +1,9 @@
-on:
-  push:
-    paths-ignore:
-      - "**/*.md"
-  pull_request:
-    paths-ignore:
-      - "**/*.md"
-
-permissions:
-  contents: read
-
+on: [push, pull_request]
 jobs:
   trailing-whitespace:
     runs-on: ubuntu-24.04
-    timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Check for trailing whitespace
@@ -43,7 +32,6 @@ jobs:
           fi
 
   compile:
-    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
@@ -79,7 +67,7 @@ jobs:
             fqbn: "esp8266:esp8266:d1_mini"
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           submodules: 'true'
@@ -125,12 +113,12 @@ jobs:
           - "esp32-c3"
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           submodules: 'true'
 
-      - uses: actions/setup-python@v7.0.0
+      - uses: actions/setup-python@v7
         with:
           python-version: '3.14'
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,7 +1,18 @@
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - "**/*.md"
+  pull_request:
+    paths-ignore:
+      - "**/*.md"
+
+permissions:
+  contents: read
+
 jobs:
   trailing-whitespace:
     runs-on: ubuntu-24.04
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v7.0.1
         with:
@@ -32,6 +43,7 @@ jobs:
           fi
 
   compile:
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
@@ -105,6 +117,7 @@ jobs:
       # "hardware lab" runner that is directly connected to a relevant device.
 
   platformio-build:
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
@@ -119,7 +132,7 @@ jobs:
 
       - uses: actions/setup-python@v7.0.0
         with:
-          python-version: '3.x'
+          python-version: '3.14'
 
       - name: Install PlatformIO
         run: pip install platformio

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -109,7 +109,6 @@ jobs:
       fail-fast: false
       matrix:
         environment:
-          - "esp8266"
           - "esp32-c3"
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -3,7 +3,7 @@ jobs:
   trailing-whitespace:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 0
       - name: Check for trailing whitespace
@@ -67,11 +67,11 @@ jobs:
             fqbn: "esp8266:esp8266:d1_mini"
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 0
           submodules: 'true'
-      - uses: arduino/compile-sketches@v1.1.2
+      - uses: arduino/compile-sketches@v1.1.3
         with:
           fqbn: ${{ matrix.fqbn }}
           sketch-paths: |

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -117,7 +117,7 @@ jobs:
           fetch-depth: 0
           submodules: 'true'
 
-      - uses: actions/setup-python@v5.4.0
+      - uses: actions/setup-python@v7.0.0
         with:
           python-version: '3.x'
 


### PR DESCRIPTION
Add a job to use PlatformIO to build ESP32-C3 version

* Filter when action runs to exclude markdown only commits.
* Add job timeouts so prevent accidental extremely long runs of the action
* Set permissions to Read only