### PR TITLE
fix(boarddef): correct Open Air OLED support flags

### DIFF
--- a/src/Main/BoardDef.cpp
+++ b/src/Main/BoardDef.cpp
@@ -304,10 +304,11 @@ const BoardDef bsps[_BOARD_MAX] = {
                     .addr = 0,
                     .supported = false,
 #else
-                    .width = 128,
-                    .height = 64,
-                    .addr = 0x3C,
-                    .supported = true,
+                    /** Open Air has no OLED display */
+                    .width = 0,
+                    .height = 0,
+                    .addr = 0,
+                    .supported = false,
 #endif
                 },
             .WDG =


### PR DESCRIPTION
## Summary
Open Air has no display; `BoardDef` incorrectly declared one (same 128x64 @ 0x3C as `ONE_INDOOR`).

## Test plan
- [x] Builds cleanly for the `esp32-c3` env (`pio run -e esp32-c3`)