### PR TITLE
Add a job to use PlatformIO to build ESP32-C3 version

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -103,3 +103,27 @@ jobs:
       # the resulting image (e.g. that it boots successfully and sends metrics)
       # but that would either require a high fidelity device emulator, or a
       # "hardware lab" runner that is directly connected to a relevant device.
+
+  platformio-build:
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        environment:
+          - "esp32-c3"
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          submodules: 'true'
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: '3.14'
+
+      - name: Install PlatformIO
+        run: pip install platformio
+
+      - name: Build with PlatformIO
+        run: pio run --environment ${{ matrix.environment }}


### PR DESCRIPTION
Documentation for compiling mentions both Arduino IDE as well as PlatformIO. 

#386 mentions that current compile with Arduino IDE results in a bootloop but with PlatformIO it runs .

Comparing the flash size usage between the two does show a significant difference.

Arduino IDE
```
Compiling sketch: examples/OneOpenAir
  Sketch uses 1945746 bytes (98%) of program storage space. Maximum is 1966080 bytes.
  Global variables use 68820 bytes (21%) of dynamic memory, leaving 258860 bytes for local variables. Maximum is 327680 bytes.
```

PlatformIO
```
RAM:   [==        ]  20.9% (used 68644 bytes from 327680 bytes)
Flash: [========= ]  89.9% (used 1767890 bytes from 1966080 bytes)
```

If instructions mention both, and there is a difference in running the two, at least should be testing a build with each method.
