### PR TITLE
[Experimental] Add HomeKit support based on HomeSpan for the ONE.

### DIFF
--- a/docs/howto-compile.md
+++ b/docs/howto-compile.md
@@ -33,6 +33,7 @@ Using library manager install the latest version (Tools ➝ Manage Libraries... 
   - `Sensirion Core` by Sensirion `^0.7.3`
   - `Sensirion UART SPS30` by Sensirion `^1.0.0`
   - `ArduinoJson` by Benoit Blanchon `^7.4.3`
+  - `HomeSpan` by Gregg `1.9.1`
 - Follow steps of ">= 3.3.0"
 
 3. On tools tab, follow settings below
@@ -47,7 +48,7 @@ Flash Frequency ➝ 80MHz
 Flash Mode ➝ QIO
 Flash Size ➝ 4MB (32Mb)
 JTAG Adapter ➝ Disabled
-Partition Scheme ➝ Minimal SPIFFS (1.9MB APP with OTA/190KB SPIFFS)
+Partition Scheme ➝ Huge APP (3MB No OTA/1MB SPIFFS)
 Upload Speed ➝ 921600
 ```
 

--- a/examples/OneOpenAir/OneOpenAir.ino
+++ b/examples/OneOpenAir/OneOpenAir.ino
@@ -63,6 +63,7 @@ CC BY-SA 4.0 Attribution-ShareAlike 4.0 International License
 #include "Libraries/airgradient-ota/src/airgradientOtaCellular.h"
 #include "esp_system.h"
 #include "freertos/projdefs.h"
+#include "homekit.h"
 
 #define LED_BAR_ANIMATION_PERIOD 100                       /** ms */
 #define DISP_UPDATE_INTERVAL 2500                          /** ms */
@@ -165,6 +166,8 @@ static AirgradientClient::PayloadType getClientPayloadType();
 static AirgradientClient::CommonPayload buildCommonPayload(Measurements::Measures &mc);
 static void saveOperatorState();
 static void restoreOperatorState();
+static void setupHomeKit();
+static void updateHomeKit();
 
 AgSchedule dispLedSchedule(DISP_UPDATE_INTERVAL, updateDisplayAndLedBar);
 AgSchedule configSchedule(WIFI_SERVER_CONFIG_SYNC_INTERVAL, configurationUpdateSchedule);
@@ -178,6 +181,11 @@ AgSchedule watchdogFeedSchedule(60000, wdgFeedUpdate);
 AgSchedule checkForUpdateSchedule(FIRMWARE_CHECK_FOR_UPDATE_MS, checkForFirmwareUpdate);
 AgSchedule networkSignalCheckSchedule(10000, networkSignalCheck);
 AgSchedule printMeasurementsSchedule(6000, printMeasurements);
+AgSchedule homekitSchedule(10000, updateHomeKit);
+
+// HomeKit pairing (SRP) is stack-heavy; enlarge the Arduino loop-task stack so
+// homeSpan.poll() has room to complete pairing without a stack overflow.
+SET_LOOP_TASK_STACK_SIZE(16 * 1024);
 
 void setup() {
   /** Serial for print debug message */
@@ -317,6 +325,12 @@ void loop() {
   // Schedule to feed external watchdog
   watchdogFeedSchedule.run();
 
+  // Service HomeKit: poll every loop for responsiveness, push values every 10s
+  if (homekitIsReady()) {
+    homekitPoll();
+    homekitSchedule.run();
+  }
+
   if (firmwareUpdateInProgress) {
     // Firmare update currently in progress, temporarily disable running sensor schedules
     delay(10000);
@@ -397,6 +411,38 @@ static void co2Update(void) {
 }
 
 void printMeasurements() { measurements.printCurrentAverage(); }
+
+// Start HomeKit, handing it the already-established WiFi connection. Called once
+// from initializeNetwork(), only in WiFi mode. The HomeSpan implementation lives
+// in homekit.cpp (a separate translation unit) so its global 'PushButton' class
+// does not collide with the AirGradient library's class of the same name.
+static void setupHomeKit() {
+  if (networkOption != UseWifi || WiFi.status() != WL_CONNECTED) {
+    return;
+  }
+
+  homekitBegin(ag->getBoardName().c_str(), ag->deviceId().c_str(),
+               ag->getVersion().c_str(), WiFi.SSID().c_str(), WiFi.psk().c_str());
+}
+
+// Read the latest sensor values and forward them to HomeKit. Runs every 10s from
+// loop(). Validity is evaluated here; invalid readings are not forwarded.
+static void updateHomeKit() {
+  if (!homekitIsReady()) {
+    return;
+  }
+
+  int co2 = measurements.get(Measurements::CO2);
+  int tvoc = measurements.get(Measurements::TVOC);
+  int nox = measurements.get(Measurements::NOx);
+  float pm25 = measurements.getCorrectedPM25(false, 1, true);
+  float temp = measurements.getCorrectedTempHum(Measurements::Temperature, 1, true);
+  float hum = measurements.getCorrectedTempHum(Measurements::Humidity, 1, true);
+
+  homekitUpdate(pm25, utils::isValidPm((int)round(pm25)), co2, utils::isValidCO2(co2),
+                tvoc, utils::isValidVOC(tvoc), nox, utils::isValidNOx(nox), temp,
+                utils::isValidTemperature(temp), hum, utils::isValidHumidity(hum));
+}
 
 static void mdnsInit(void) {
   if (!MDNS.begin(localServer.getHostname().c_str())) {
@@ -1172,6 +1218,8 @@ void initializeNetwork() {
     localServer.begin();
     // Apply mqtt connection if configured
     initMqtt();
+    // Expose sensors to Apple HomeKit over the same WiFi connection
+    setupHomeKit();
 
     // Ignore the rest if cloud connection to AirGradient is disabled
     if (configuration.isCloudConnectionDisabled()) {

--- a/examples/OneOpenAir/homekit.cpp
+++ b/examples/OneOpenAir/homekit.cpp
@@ -1,0 +1,171 @@
+// Apple HomeKit support for the AirGradient ONE / Open Air, via HomeSpan.
+//
+// This file is deliberately isolated from the AirGradient library headers: it
+// includes HomeSpan.h but not AirGradient.h. Both libraries define a global
+// class named `PushButton`, so they cannot coexist in one translation unit.
+// The sketch talks to this file only through the plain interface in homekit.h.
+
+#include "homekit.h"
+
+#include <Arduino.h>
+#include <WiFi.h>
+
+#include "HomeSpan.h"
+
+namespace {
+
+bool ready = false;
+
+Characteristic::AirQuality *hkAirQuality = nullptr;
+Characteristic::PM25Density *hkPm25 = nullptr;
+Characteristic::VOCDensity *hkVoc = nullptr;
+Characteristic::NitrogenDioxideDensity *hkNo2 = nullptr;
+Characteristic::CarbonDioxideDetected *hkCo2Detected = nullptr;
+Characteristic::CarbonDioxideLevel *hkCo2Level = nullptr;
+Characteristic::CurrentTemperature *hkTemp = nullptr;
+Characteristic::CurrentRelativeHumidity *hkHum = nullptr;
+
+// PM2.5 sub-index, on HomeKit's AirQuality scale, adapted from the breakpoints
+// used to control the LEDs (if PM2.5 is the chosen LED mode).
+int pm25Index(float pm25) {
+  if (pm25 <= 9) {
+    return 1;
+  } else if (pm25 <= 35) {
+    return 2;
+  } else if (pm25 <= 55) {
+    return 3;
+  } else if (pm25 <= 125) {
+    return 4;
+  }
+  return 5;
+}
+
+// Logged on every HomeSpan status change (WiFi connecting, pairing needed,
+// paired, etc.) — fires regardless of log level.
+void hkStatusCallback(HS_STATUS status) {
+  Serial.printf("[HomeKit] status: %s\n", homeSpan.statusString(status));
+}
+
+// Logged when a controller completes pairing or an existing pairing is removed.
+void hkPairCallback(boolean isPaired) {
+  Serial.printf("[HomeKit] %s\n", isPaired ? "PAIRED" : "unpaired / pairing lost");
+}
+
+// CO2 sub-index, on HomeKit's AirQuality scale, adapted from the breakpoints
+// used to control the LEDs (if CO2 is the chosen LED mode).
+int co2Index(int co2) {
+  if (co2 <= 600) {
+    return 1;
+  } else if (co2 <= 1000) {
+    return 2;
+  } else if (co2 <= 2000) {
+    return 3;
+  } else if (co2 <= 3000) {
+    return 4;
+  }
+  return 5;
+}
+
+} // namespace
+
+void homekitBegin(const char *model, const char *serialNumber,
+                  const char *firmwareVersion, const char *ssid, const char *psk) {
+  // Adopt the firmware's existing WiFi connection instead of letting HomeSpan
+  // manage WiFi: with credentials set and WiFi already up, HomeSpan's
+  // checkConnect() reuses the connection rather than re-associating. Serial
+  // input is disabled so HomeSpan's CLI does not consume the firmware's stream.
+  homeSpan.setWifiCredentials(ssid, psk);
+  homeSpan.setSerialInputDisable(true);
+  homeSpan.setSketchVersion(firmwareVersion);
+
+  // The AirGradient LocalServer already binds port 80, and HomeSpan's HAP server
+  // defaults to 80 too. Without this, HomeSpan can't bind, so the accessory is
+  // discoverable over mDNS but every pairing connection fails ("accessory not
+  // reachable"). Move HAP to a free port.
+  homeSpan.setPortNum(1201);
+
+  // Diagnostics for pairing/sync. Log level 1 surfaces HomeSpan's own HAP and
+  // pairing progress; the status/pair callbacks mark the key transitions.
+  homeSpan.setLogLevel(1);
+  homeSpan.setStatusCallback(hkStatusCallback);
+  homeSpan.setPairCallback(hkPairCallback);
+
+  homeSpan.begin(Category::Sensors, "AirGradient ONE", "airgradient", model);
+
+  new SpanAccessory();
+  new Service::AccessoryInformation();
+  new Characteristic::Identify();
+  new Characteristic::Manufacturer("AirGradient");
+  new Characteristic::Model(model);
+  new Characteristic::SerialNumber(serialNumber);
+  new Characteristic::FirmwareRevision(firmwareVersion);
+  new Characteristic::Name("AirGradient ONE");
+
+  new Service::AirQualitySensor();
+  new Characteristic::Name("Air Quality");
+  hkAirQuality = new Characteristic::AirQuality(0);
+  hkPm25 = new Characteristic::PM25Density(0);
+  hkVoc = new Characteristic::VOCDensity(0);
+  hkNo2 = new Characteristic::NitrogenDioxideDensity(0);
+
+  new Service::CarbonDioxideSensor();
+  new Characteristic::Name("CO2");
+  hkCo2Detected = new Characteristic::CarbonDioxideDetected(0);
+  hkCo2Level = new Characteristic::CarbonDioxideLevel(0);
+
+  new Service::TemperatureSensor();
+  new Characteristic::Name("Temperature");
+  hkTemp = new Characteristic::CurrentTemperature(0);
+
+  new Service::HumiditySensor();
+  new Characteristic::Name("Humidity");
+  hkHum = new Characteristic::CurrentRelativeHumidity(0);
+
+  ready = true;
+  Serial.println("HomeKit accessory ready");
+}
+
+void homekitPoll() {
+  if (ready) {
+    homeSpan.poll();
+  }
+}
+
+bool homekitIsReady() { return ready; }
+
+void homekitUpdate(float pm25, bool pm25Valid, int co2, bool co2Valid, int tvoc,
+                   bool tvocValid, int nox, bool noxValid, float temperature,
+                   bool temperatureValid, float humidity, bool humidityValid) {
+  if (!ready) {
+    return;
+  }
+
+  // Air quality index: worst (highest) of the available PM2.5 and CO2 sub-indices.
+  int airQuality = 0;
+  if (pm25Valid) {
+    airQuality = max(airQuality, pm25Index(pm25));
+    hkPm25->setVal(pm25);
+  }
+  if (co2Valid) {
+    airQuality = max(airQuality, co2Index(co2));
+    hkCo2Level->setVal(co2);
+    hkCo2Detected->setVal(co2 > 1000 ? 1 : 0);
+  }
+  if (pm25Valid || co2Valid) {
+    hkAirQuality->setVal(airQuality);
+  }
+
+  // TVOC/NOx are AirGradient index values (not ug/m3 densities), forwarded as-is.
+  if (tvocValid) {
+    hkVoc->setVal(tvoc);
+  }
+  if (noxValid) {
+    hkNo2->setVal(nox);
+  }
+  if (temperatureValid) {
+    hkTemp->setVal(temperature);
+  }
+  if (humidityValid) {
+    hkHum->setVal(humidity);
+  }
+}

--- a/examples/OneOpenAir/homekit.h
+++ b/examples/OneOpenAir/homekit.h
@@ -1,0 +1,30 @@
+#ifndef ONEOPENAIR_HOMEKIT_H
+#define ONEOPENAIR_HOMEKIT_H
+
+// Bridge between the OneOpenAir sketch and Apple HomeKit (HomeSpan).
+//
+// The implementation lives in homekit.cpp, which includes HomeSpan.h but never
+// AirGradient.h. This keeps HomeSpan's global `PushButton` class out of the same
+// translation unit as the AirGradient library's class of the same name, which
+// would otherwise collide. This header therefore exposes only plain types.
+
+// Build the HomeKit accessory and adopt the WiFi connection the firmware has
+// already established (HomeSpan reuses it rather than managing WiFi itself).
+// Call once, after WiFi is connected. All strings are copied by HomeSpan.
+void homekitBegin(const char *model, const char *serialNumber,
+                  const char *firmwareVersion, const char *ssid, const char *psk);
+
+// Service HomeKit. Call frequently (every loop iteration).
+void homekitPoll();
+
+// True once homekitBegin() has built the accessory.
+bool homekitIsReady();
+
+// Forward the latest readings to HomeKit. Each *Valid flag indicates whether the
+// paired reading is currently valid; invalid readings are not forwarded, leaving
+// the previous HomeKit value intact.
+void homekitUpdate(float pm25, bool pm25Valid, int co2, bool co2Valid, int tvoc,
+                   bool tvocValid, int nox, bool noxValid, float temperature,
+                   bool temperatureValid, float humidity, bool humidityValid);
+
+#endif // ONEOPENAIR_HOMEKIT_H

--- a/partitions.csv
+++ b/partitions.csv
@@ -1,7 +1,6 @@
 # Name   ,Type ,SubType  ,Offset   ,Size     ,Flags
 nvs      ,data ,nvs      ,0x9000   ,0x5000   ,
 otadata  ,data ,ota      ,0xe000   ,0x2000   ,
-app0     ,app  ,ota_0    ,0x10000  ,0x1E0000 ,
-app1     ,app  ,ota_1    ,0x1F0000 ,0x1E0000 ,
-spiffs   ,data ,spiffs   ,0x3D0000 ,0x20000  ,
+app0     ,app  ,ota_0    ,0x10000  ,0x300000 ,
+spiffs   ,data ,spiffs   ,0x310000 ,0xE0000  ,
 coredump ,data ,coredump ,0x3F0000 ,0x10000  ,

--- a/platformio.ini
+++ b/platformio.ini
@@ -9,7 +9,7 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [env:esp32-c3]
-platform = espressif32
+platform = espressif32@7.0.1
 board = esp32-c3-devkitm-1
 framework = arduino
 build_flags = !echo '-fno-exceptions -D ARDUINO_USB_CDC_ON_BOOT=1 -D ARDUINO_USB_MODE=1 -D AG_LOG_LEVEL=AG_LOG_LEVEL_INFO -D ARDUINOJSON_ENABLE_PROGMEM=0 -D GIT_VERSION=\\"'$(git describe --tags --always --dirty)'\\"'
@@ -30,6 +30,7 @@ lib_deps =
 	sensirion/Sensirion Core@^0.7.3
 	sensirion/Sensirion UART SPS30@^1.0.0
 	bblanchon/ArduinoJson@^7.4.3
+	homespan/HomeSpan@1.9.1
 
 [env:esp8266]
 platform = espressif8266


### PR DESCRIPTION
## Summary and Features

This PR adds support for reporting to HomeKit using [HomeSpan](https://github.com/HomeSpan/HomeSpan) for the ONE. (It is the only one I have and so the only one I tested.)

When set up, the ONE reports all the readings it has, with some caveats (see below). It appears in HomeKit as little pills, since it's a read-only sensor and not an interactive thing.

<img width="590" height="193" alt="Screenshot 2026-07-27 at 10 29 57" src="https://github.com/user-attachments/assets/68a4e6ed-9325-4d69-84b0-773d1fa5671b" />

To try it out, after flashing this firmware, pair with the code **466-37-726** (HomeSpan's default value).

## Technical Details and Caveats

This PR has significant shortcomings, however, so it needs input from other HomeKit users (i.e. what they want) and AirGradient (i.e. what is acceptable) if it is to be incorporated upstream. That said, I'm opening this PR for discoverability for other potential HomeKit tinkerers.

The major caveats are:

- HomeSpan adds ~200KB, which pushes the binary size over the 1.9MB limit. (See also #386.) This PR switches to the "Huge APP" configuration, which **disables OTA updates** due to lack of space.
- HomeKit wants absolute ug/m3 measurements for VOC and NOx, but the ONE only reports relative indices. This PR just **reports the index as if it's the concentration**. (Also HomeKit uses the terminology "NO2", not the broader "NOx".)

And these aren't really caveats so much as things to be aware of/corners I cut temporarily:

- The air quality index is currently reported as the max of the CO2/PM2.5 index because I didn't want to go down the rabbit hole of computing the full formulas.
- HomeSpan is pegged to 1.9.1 because that's the last version that supports this board.
- I had to configure HomeSpan with a non-default port (here, 1201) because otherwise it would fight with the API server on 80.
- HomeKit hides the specific readings (like PM2.5) behind a tap, which is annoying if you want the details up-front, and I can't figure out how to configure it otherwise. For some reason it also lists the CO2 sensor as just "Carbon Dioxide Sensor" without giving you figures until you tap into it. Perhaps third-party HomeKit viewers (Eve?) don't have this problem.