### PR TITLE
feat(OneOpenAir): add robust board identity

### DIFF
--- a/examples/OneOpenAir/OneOpenAir.ino
+++ b/examples/OneOpenAir/OneOpenAir.ino
@@ -31,6 +31,7 @@ CC BY-SA 4.0 Attribution-ShareAlike 4.0 International License
 #endif
 
 #include "AgConfigure.h"
+#include "AgHardwareIdentity.h"
 #include "AgSatellites.h"
 #include "AgSchedule.h"
 #include "AgStateMachine.h"
@@ -105,6 +106,7 @@ static TaskHandle_t mqttTask = NULL;
 static Configuration configuration(Serial);
 static Measurements measurements(configuration);
 static AirGradient *ag;
+static AgHardwareIdentity hardwareIdentity;
 static bool oledDetected = false;
 static AgSatellites *satellites = nullptr;
 static OledDisplay oledDisplay(configuration, measurements, Serial);
@@ -168,7 +170,7 @@ static AirgradientClient::PayloadType getClientPayloadType();
 static AirgradientClient::CommonPayload buildCommonPayload(Measurements::Measures &mc);
 static void saveOperatorState();
 static void restoreOperatorState();
-static bool isIndoorBoardSelected();
+static BoardType getBoardType();
 static void requestBoardSelectionReboot();
 
 AgSchedule dispLedSchedule(DISP_UPDATE_INTERVAL, updateDisplayAndLedBar);
@@ -189,6 +191,7 @@ void setup() {
   Serial.begin(115200);
   delay(100); /** For bester show log */
   mainTaskHandle = xTaskGetCurrentTaskHandle();
+  hardwareIdentity.begin();
 
   // Enable cullular module power board
   pinMode(GPIO_EXPANSION_CARD_POWER, OUTPUT);
@@ -206,23 +209,16 @@ void setup() {
   Wire.begin(I2C_SDA_PIN, I2C_SCL_PIN);
   delay(1000);
 
-  /** Detect board type from OLED or persisted model. */
+  /** Detect board type from eFuse, OLED, or persisted model. */
   Wire.beginTransmission(OLED_I2C_ADDR);
   oledDetected = Wire.endTransmission() == 0x00;
-  if (isIndoorBoardSelected()) {
-    ag = new AirGradient(BoardType::ONE_INDOOR);
-  } else {
-    ag = new AirGradient(BoardType::OPEN_AIR_OUTDOOR);
-  }
+  ag = new AirGradient(getBoardType());
   Serial.println("Detected " + ag->getBoardName());
-  Serial.printf(
-      "Board selection: OLED=%s, model=%s, source=%s, selected=%s\n",
-      oledDetected ? "detected" : "not detected",
-      configuration.getModel().c_str(),
-      oledDetected
-          ? "OLED"
-          : (configuration.getModel().startsWith("I-") ? "model" : "default"),
-      ag->getBoardName().c_str());
+  Serial.printf("Board selection: eFuse=%s (0x%02X), OLED=%s, model=%s, "
+                "selected=%s\n",
+                hardwareIdentity.getValueName(), hardwareIdentity.getRawValue(),
+                oledDetected ? "detected" : "not detected",
+                configuration.getModel().c_str(), ag->getBoardName().c_str());
 
   /** Print device ID into log */
   Serial.println("Serial nr: " + ag->deviceId());
@@ -338,10 +334,10 @@ void loop() {
   }
 
   if (ulTaskNotifyTake(pdTRUE, 0) > 0) {
-    Serial.printf("Rebooting in %u ms to apply model-based board selection\n",
+    Serial.printf("Rebooting in %u ms to apply hardware board selection\n",
                   BOARD_SELECTION_REBOOT_DELAY_MS);
     if (ag->isOne()) {
-      oledDisplay.setText("Model changed", "Rebooting...", "");
+      oledDisplay.setText("Hardware changed", "Rebooting...", "");
     }
     delay(BOARD_SELECTION_REBOOT_DELAY_MS);
     esp_restart();
@@ -1352,20 +1348,25 @@ static void configUpdateHandle() {
   updateDisplayAndLedBar();
 }
 
-static bool isIndoorBoardSelected() {
-  return oledDetected || configuration.getModel().startsWith("I-");
+static BoardType getBoardType() {
+  return hardwareIdentity.resolve(oledDetected, configuration.getModel());
 }
 
 static void requestBoardSelectionReboot() {
-  const bool selectIndoor = isIndoorBoardSelected();
-  if (selectIndoor == ag->isOne()) {
+  if (hardwareIdentity.isProvisioned()) {
+    return;
+  }
+
+  const BoardType boardType = getBoardType();
+  if (boardType == ag->getBoardType()) {
     return;
   }
 
   Serial.printf("Board selection changed: OLED=%s, model=%s, selected=%s\n",
                 oledDetected ? "detected" : "not detected",
                 configuration.getModel().c_str(),
-                selectIndoor ? "ONE_INDOOR" : "OPEN_AIR_OUTDOOR");
+                boardType == BoardType::ONE_INDOOR ? "ONE_INDOOR"
+                                                   : "OPEN_AIR_OUTDOOR");
   if (mainTaskHandle == NULL) {
     Serial.println(
         "Cannot request board selection reboot: main task unavailable");

--- a/examples/OneOpenAir/OneOpenAir.ino
+++ b/examples/OneOpenAir/OneOpenAir.ino
@@ -79,6 +79,7 @@ CC BY-SA 4.0 Attribution-ShareAlike 4.0 International License
 #define SENSOR_PM_UPDATE_INTERVAL 2000                     /** ms */
 #define SENSOR_TEMP_HUM_UPDATE_INTERVAL 6000               /** ms */
 #define DISPLAY_DELAY_SHOW_CONTENT_MS 2000                 /** ms */
+#define BOARD_SELECTION_REBOOT_DELAY_MS 3000               /** ms */
 #define FIRMWARE_CHECK_FOR_UPDATE_MS (60 * 60 * 1000)      /** ms */
 #define TIME_TO_START_POWER_CYCLE_CELLULAR_MODULE (1 * 60) /** minutes */
 #define TIMEOUT_WAIT_FOR_CELLULAR_MODULE_READY (2 * 60)    /** minutes */
@@ -104,6 +105,7 @@ static TaskHandle_t mqttTask = NULL;
 static Configuration configuration(Serial);
 static Measurements measurements(configuration);
 static AirGradient *ag;
+static bool oledDetected = false;
 static AgSatellites *satellites = nullptr;
 static OledDisplay oledDisplay(configuration, measurements, Serial);
 static StateMachine stateMachine(oledDisplay, Serial, measurements, configuration);
@@ -116,6 +118,7 @@ static AirgradientClient *agClient;
 
 enum NetworkOption { UseWifi, UseCellular };
 NetworkOption networkOption;
+static TaskHandle_t mainTaskHandle = NULL;
 TaskHandle_t handleNetworkTask = NULL;
 static bool firmwareUpdateInProgress = false;
 
@@ -165,6 +168,8 @@ static AirgradientClient::PayloadType getClientPayloadType();
 static AirgradientClient::CommonPayload buildCommonPayload(Measurements::Measures &mc);
 static void saveOperatorState();
 static void restoreOperatorState();
+static bool isIndoorBoardSelected();
+static void requestBoardSelectionReboot();
 
 AgSchedule dispLedSchedule(DISP_UPDATE_INTERVAL, updateDisplayAndLedBar);
 AgSchedule configSchedule(WIFI_SERVER_CONFIG_SYNC_INTERVAL, configurationUpdateSchedule);
@@ -183,6 +188,7 @@ void setup() {
   /** Serial for print debug message */
   Serial.begin(115200);
   delay(100); /** For bester show log */
+  mainTaskHandle = xTaskGetCurrentTaskHandle();
 
   // Enable cullular module power board
   pinMode(GPIO_EXPANSION_CARD_POWER, OUTPUT);
@@ -200,15 +206,23 @@ void setup() {
   Wire.begin(I2C_SDA_PIN, I2C_SCL_PIN);
   delay(1000);
 
-  /** Detect board type: ONE_INDOOR has OLED display, Scan the I2C address to
-   * identify board type */
+  /** Detect board type from OLED or persisted model. */
   Wire.beginTransmission(OLED_I2C_ADDR);
-  if (Wire.endTransmission() == 0x00) {
+  oledDetected = Wire.endTransmission() == 0x00;
+  if (isIndoorBoardSelected()) {
     ag = new AirGradient(BoardType::ONE_INDOOR);
   } else {
     ag = new AirGradient(BoardType::OPEN_AIR_OUTDOOR);
   }
   Serial.println("Detected " + ag->getBoardName());
+  Serial.printf(
+      "Board selection: OLED=%s, model=%s, source=%s, selected=%s\n",
+      oledDetected ? "detected" : "not detected",
+      configuration.getModel().c_str(),
+      oledDetected
+          ? "OLED"
+          : (configuration.getModel().startsWith("I-") ? "model" : "default"),
+      ag->getBoardName().c_str());
 
   /** Print device ID into log */
   Serial.println("Serial nr: " + ag->deviceId());
@@ -321,6 +335,16 @@ void loop() {
     // Firmare update currently in progress, temporarily disable running sensor schedules
     delay(10000);
     return;
+  }
+
+  if (ulTaskNotifyTake(pdTRUE, 0) > 0) {
+    Serial.printf("Rebooting in %u ms to apply model-based board selection\n",
+                  BOARD_SELECTION_REBOOT_DELAY_MS);
+    if (ag->isOne()) {
+      oledDisplay.setText("Model changed", "Rebooting...", "");
+    }
+    delay(BOARD_SELECTION_REBOOT_DELAY_MS);
+    esp_restart();
   }
 
   // Schedule to update display and led
@@ -1322,8 +1346,32 @@ static void configUpdateHandle() {
     }
   }
 
+  requestBoardSelectionReboot();
+
   // Update display and led bar notification based on updated configuration
   updateDisplayAndLedBar();
+}
+
+static bool isIndoorBoardSelected() {
+  return oledDetected || configuration.getModel().startsWith("I-");
+}
+
+static void requestBoardSelectionReboot() {
+  const bool selectIndoor = isIndoorBoardSelected();
+  if (selectIndoor == ag->isOne()) {
+    return;
+  }
+
+  Serial.printf("Board selection changed: OLED=%s, model=%s, selected=%s\n",
+                oledDetected ? "detected" : "not detected",
+                configuration.getModel().c_str(),
+                selectIndoor ? "ONE_INDOOR" : "OPEN_AIR_OUTDOOR");
+  if (mainTaskHandle == NULL) {
+    Serial.println(
+        "Cannot request board selection reboot: main task unavailable");
+    return;
+  }
+  xTaskNotifyGive(mainTaskHandle);
 }
 
 static void updateDisplayAndLedBar(void) {

--- a/src/AgConfigure.cpp
+++ b/src/AgConfigure.cpp
@@ -100,6 +100,11 @@ static bool jsonTypeInvalid(JSONVar root, String validType) {
   return true;
 }
 
+static bool isValidLocalModel(const String &model) {
+  return model.length() > 2 &&
+         (model.startsWith("I-") || model.startsWith("O-"));
+}
+
 /**
  * @brief Get LedBarMode Name
  *
@@ -941,24 +946,29 @@ bool Configuration::parse(String data, bool isLocal) {
     }
   }
 
-  /** Parse data only got from AirGradient server */
-  if (isLocal == false) {
-    if (JSON.typeof_(root[jprop_model]) == "string") {
-      String model = root[jprop_model];
-      String oldModel = jconfig[jprop_model];
-      if (model != oldModel) {
-        changed = true;
-        configLogInfo(String(jprop_model), oldModel, model);
-        jconfig[jprop_model] = model;
-      }
-    } else {
-      if (jsonTypeInvalid(root[jprop_model], "string")) {
-        failedMessage = jsonTypeInvalidMessage(String(jprop_model), "string");
-        jsonInvalid();
-        return false;
-      }
+  if (JSON.typeof_(root[jprop_model]) == "string") {
+    String model = root[jprop_model];
+    if (isLocal && !isValidLocalModel(model)) {
+      failedMessage = jsonValueInvalidMessage(String(jprop_model), model);
+      jsonInvalid();
+      return false;
     }
 
+    String oldModel = jconfig[jprop_model];
+    if (model != oldModel) {
+      changed = true;
+      configLogInfo(String(jprop_model), oldModel, model);
+      jconfig[jprop_model] = model;
+    }
+  } else {
+    if (jsonTypeInvalid(root[jprop_model], "string")) {
+      failedMessage = jsonTypeInvalidMessage(String(jprop_model), "string");
+      jsonInvalid();
+      return false;
+    }
+  }
+
+  if (isLocal == false) {
     // Check for satellites
     if (updateSatellites(root)) {
       changed = true;

--- a/src/AgHardwareIdentity.cpp
+++ b/src/AgHardwareIdentity.cpp
@@ -1,0 +1,82 @@
+#include "AgHardwareIdentity.h"
+
+#if defined(ESP32)
+#include "sdkconfig.h"
+#endif
+
+#if defined(CONFIG_IDF_TARGET_ESP32C3)
+#include "esp_efuse.h"
+#endif
+
+namespace {
+
+constexpr uint8_t HARDWARE_IDENTITY_UNPROVISIONED = 0x00;
+constexpr uint8_t HARDWARE_IDENTITY_INDOOR = 0xA5;
+constexpr uint8_t HARDWARE_IDENTITY_OUTDOOR = 0x5A;
+
+} // namespace
+
+void AgHardwareIdentity::begin(void) {
+  _value = Value::Unprovisioned;
+  _rawValue = HARDWARE_IDENTITY_UNPROVISIONED;
+
+#if defined(CONFIG_IDF_TARGET_ESP32C3)
+  uint8_t block[32] = {};
+  if (esp_efuse_read_block(EFUSE_BLK_USER_DATA, block, 0, sizeof(block) * 8) !=
+      ESP_OK) {
+    _value = Value::Invalid;
+    return;
+  }
+  _rawValue = block[0];
+
+  switch (_rawValue) {
+  case HARDWARE_IDENTITY_UNPROVISIONED:
+    _value = Value::Unprovisioned;
+    break;
+  case HARDWARE_IDENTITY_INDOOR:
+    _value = Value::Indoor;
+    break;
+  case HARDWARE_IDENTITY_OUTDOOR:
+    _value = Value::Outdoor;
+    break;
+  default:
+    _value = Value::Invalid;
+    break;
+  }
+#endif
+}
+
+BoardType AgHardwareIdentity::resolve(bool oledDetected,
+                                      const String &model) const {
+  if (_value == Value::Indoor) {
+    return BoardType::ONE_INDOOR;
+  }
+  if (_value == Value::Outdoor) {
+    return BoardType::OPEN_AIR_OUTDOOR;
+  }
+  if (oledDetected || model.startsWith("I-")) {
+    return BoardType::ONE_INDOOR;
+  }
+  return BoardType::OPEN_AIR_OUTDOOR;
+}
+
+bool AgHardwareIdentity::isProvisioned(void) const {
+  return _value == Value::Indoor || _value == Value::Outdoor;
+}
+
+uint8_t AgHardwareIdentity::getRawValue(void) const { return _rawValue; }
+
+const char *AgHardwareIdentity::getValueName(void) const {
+  switch (_value) {
+  case Value::Unprovisioned:
+    return "unprovisioned";
+  case Value::Indoor:
+    return "indoor";
+  case Value::Outdoor:
+    return "outdoor";
+  case Value::Invalid:
+    return "invalid";
+  }
+
+  return "unknown";
+}

--- a/src/AgHardwareIdentity.h
+++ b/src/AgHardwareIdentity.h
@@ -1,0 +1,29 @@
+#ifndef AG_HARDWARE_IDENTITY_H
+#define AG_HARDWARE_IDENTITY_H
+
+#include "Main/BoardDef.h"
+#include <Arduino.h>
+#include <stdint.h>
+
+class AgHardwareIdentity {
+public:
+  void begin(void);
+  BoardType resolve(bool oledDetected, const String &model) const;
+
+  bool isProvisioned(void) const;
+  uint8_t getRawValue(void) const;
+  const char *getValueName(void) const;
+
+private:
+  enum class Value {
+    Unprovisioned,
+    Indoor,
+    Outdoor,
+    Invalid,
+  };
+
+  Value _value = Value::Unprovisioned;
+  uint8_t _rawValue = 0;
+};
+
+#endif /** AG_HARDWARE_IDENTITY_H */

--- a/tools/program_hardware_identity.py
+++ b/tools/program_hardware_identity.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+
+"""Program the AirGradient hardware identity into ESP32-C3 eFuse BLK3.
+
+The script accepts ``indoor`` or ``outdoor``, requires BLK3 to be blank, burns
+the corresponding identity, and verifies the result. eFuse writes are
+irreversible.
+
+Dependency:
+    python3 -m pip install esptool
+
+The installation must provide ``espefuse.py`` on PATH. Use ``--espefuse`` to
+specify another executable path.
+"""
+
+import argparse
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+IDENTITIES = {
+    "indoor": {
+        "value": 0xA5,
+        "bits": (0, 2, 5, 7),
+    },
+    "outdoor": {
+        "value": 0x5A,
+        "bits": (1, 3, 4, 6),
+    },
+}
+
+
+def run_espefuse(espefuse: str, port: str, *args: str) -> None:
+    command = [
+        espefuse,
+        "--chip",
+        "esp32c3",
+        "--port",
+        port,
+        *args,
+    ]
+    print("+", " ".join(command), flush=True)
+    subprocess.run(command, check=True)
+
+
+def read_user_data(espefuse: str, port: str) -> bytes:
+    with tempfile.TemporaryDirectory(prefix="ag-efuse-") as directory:
+        dump_path = Path(directory) / "efuse.bin"
+        run_espefuse(espefuse, port, "dump", "--file_name", str(dump_path))
+
+        block_path = Path(directory) / "efuse3.bin"
+        try:
+            data = block_path.read_bytes()
+        except OSError as error:
+            raise RuntimeError(f"cannot read BLK3 dump: {error}") from error
+
+    if len(data) != 32:
+        raise RuntimeError(f"unexpected BLK3 size: {len(data)} bytes")
+    return data
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Program the One/Open Air hardware identity in ESP32-C3 BLK3."
+    )
+    parser.add_argument("identity", choices=IDENTITIES)
+    parser.add_argument("--port", default="/dev/ttyACM0")
+    parser.add_argument("--espefuse", default="espefuse.py")
+    args = parser.parse_args()
+
+    identity = IDENTITIES[args.identity]
+
+    try:
+        before = read_user_data(args.espefuse, args.port)
+        if any(before):
+            print(
+                f"ERROR: BLK3 is not blank: {before.hex()}",
+                file=sys.stderr,
+            )
+            return 1
+
+        bits = tuple(str(bit) for bit in identity["bits"])
+        run_espefuse(
+            args.espefuse,
+            args.port,
+            "--do-not-confirm",
+            "burn_bit",
+            "BLOCK_USR_DATA",
+            *bits,
+        )
+
+        after = read_user_data(args.espefuse, args.port)
+        expected = bytes([identity["value"]]) + bytes(31)
+        if after != expected:
+            print(
+                f"ERROR: BLK3 verification failed: expected {expected.hex()}, "
+                f"read {after.hex()}",
+                file=sys.stderr,
+            )
+            return 1
+    except (OSError, subprocess.CalledProcessError, RuntimeError) as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+
+    print(
+        f"Hardware identity programmed: {args.identity} "
+        f"(BLK3 byte 0 = 0x{identity['value']:02X})"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/vhub/OneOpenAir.vhub.json
+++ b/vhub/OneOpenAir.vhub.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "rev": "1531b84",
+  "rev": "5d88234",
   "product": {
     "slug": "one-open-air",
     "name": "ONE Indoor & Open Air",
@@ -27,6 +27,33 @@
       "description": "OPEN_AIR_OUTDOOR board is correctly identified at boot",
       "expected_result": "Serial log contains \"Detected OPEN_AIR_OUTDOOR\".",
       "notes": "Requires: serial log. Open Air has no display, so this test is log-only."
+    },
+    {
+      "id": "boot.board-detect.model-indoor-fallback",
+      "category": "Boot & Hardware Detection",
+      "sub_category": "Board detection",
+      "applies_to": ["ONE_INDOOR"],
+      "description": "A persisted I- model selects ONE_INDOOR when the OLED probe fails",
+      "expected_result": "With an unprovisioned eFuse, the OLED unavailable, and persisted model set to I-9PSL, the serial log contains \"Detected ONE_INDOOR\" and \"Board selection: eFuse=unprovisioned (0x00), OLED=not detected, model=I-9PSL, selected=ONE_INDOOR\".",
+      "notes": "Requires an unprovisioned device and a controlled OLED-probe failure, such as a disconnected OLED. Restore the normal model after the test."
+    },
+    {
+      "id": "boot.board-detect.oled-override",
+      "category": "Boot & Hardware Detection",
+      "sub_category": "Board detection",
+      "applies_to": ["ONE_INDOOR"],
+      "description": "A detected OLED overrides a persisted O- model",
+      "expected_result": "With an unprovisioned eFuse, model set to O-1PST, and the OLED connected, the serial log contains \"Detected ONE_INDOOR\" and \"Board selection: eFuse=unprovisioned (0x00), OLED=detected, model=O-1PST, selected=ONE_INDOOR\".",
+      "notes": "Requires an unprovisioned ONE_INDOOR unit and configurationControl set to local or both. Restore the normal model after the test."
+    },
+    {
+      "id": "boot.board-detect.efuse-identity",
+      "category": "Boot & Hardware Detection",
+      "sub_category": "Board detection",
+      "applies_to": ["ONE_INDOOR", "OPEN_AIR_OUTDOOR"],
+      "description": "A provisioned eFuse identity is authoritative for board selection",
+      "expected_result": "An indoor-provisioned device logs eFuse=indoor (0xA5) and selected=ONE_INDOOR. An outdoor-provisioned device logs eFuse=outdoor (0x5A) and selected=OPEN_AIR_OUTDOOR. Selection remains unchanged when OLED detection or the configured model conflicts with eFuse.",
+      "notes": "Requires devices provisioned with tools/program_hardware_identity.py. eFuse writes are irreversible; use manufacturing samples with known identities."
     },
     {
       "id": "boot.firmware-model.indoor-i-9psl",
@@ -756,6 +783,33 @@
       "description": "PUT /config applies configuration changes and returns success or failure",
       "expected_result": "HTTP PUT to /config with a valid recognized JSON config change (e.g. {\"temperatureUnit\":\"f\"}) returns 200 with body \"Success\"; the change takes effect immediately where applicable. Invalid JSON or invalid value/type for a recognized field returns 400 with config.getFailedMessage(). Unknown fields may be ignored and still return \"Success\".",
       "notes": "Requires: curl/Postman. Local PUT is only accepted when configurationControl is local or both. If already cloud, local PUT returns 400 with the cloud-only message, except a PUT that changes configurationControl away from cloud is handled by config parsing and can succeed."
+    },
+    {
+      "id": "local-server.put-config.model",
+      "category": "Local Server (WiFi)",
+      "sub_category": "Configuration model",
+      "applies_to": ["ONE_INDOOR"],
+      "description": "PUT /config accepts a locally configured I- or O- model",
+      "expected_result": "With configurationControl set to local or both, PUT {\"model\":\"I-9PSL\"} and PUT {\"model\":\"O-1PST\"} each return 200 with body \"Success\". GET /config returns the stored model. On an unprovisioned device, a reboot occurs only if the effective board selection changes.",
+      "notes": "Requires a ONE_INDOOR unit because Open Air GET /config replaces the stored model with the runtime firmware mode. A provisioned eFuse is authoritative, so model updates are stored without changing board selection or rebooting."
+    },
+    {
+      "id": "local-server.put-config.model-invalid",
+      "category": "Local Server (WiFi)",
+      "sub_category": "Configuration model",
+      "applies_to": ["ONE_INDOOR", "OPEN_AIR_OUTDOOR"],
+      "description": "PUT /config rejects a local model without an I- or O- prefix",
+      "expected_result": "With configurationControl set to local or both, PUT {\"model\":\"DIY-PRO-I-4.2PS\"}, {\"model\":\"invalid\"}, or {\"model\":\"\"} returns 400 and leaves the stored model unchanged.",
+      "notes": "A local model must contain at least one character after the I- or O- prefix. Cloud-provided model strings remain backward compatible and are not restricted by this local validation."
+    },
+    {
+      "id": "local-server.put-config.model-reboot",
+      "category": "Local Server (WiFi)",
+      "sub_category": "Configuration model",
+      "applies_to": ["OPEN_AIR_OUTDOOR"],
+      "description": "A model update reboots when it changes the effective board selection",
+      "expected_result": "On an Open Air unit with an unprovisioned eFuse and no OLED, PUT {\"model\":\"I-9PSL\"} returns 200, persists the model, logs a board-selection change, then reboots. The next boot logs eFuse=unprovisioned, model=I-9PSL, and selected=ONE_INDOOR.",
+      "notes": "Requires an unprovisioned device. Restore an O- model after the test. Provisioned devices do not reboot for model updates because eFuse is authoritative."
     },
     {
       "id": "local-server.get-measures-current",


### PR DESCRIPTION
### Summary

Improve ONE/Open Air board selection so failed OLED detection does not misclassify indoor hardware, while allowing manufacturing to provision an authoritative ESP32-C3 eFuse identity.

### Changes

- Allow validated `I-` and `O-` model values through local configuration
- Use OLED and persisted model as the legacy board-selection fallback
- Add authoritative indoor/outdoor identity from ESP32-C3 eFuse BLK3
- Reboot when an unprovisioned device receives a model that changes its board selection
- Add a manufacturing tool that checks, programs, and verifies BLK3 identity
- Extend VHUB coverage for model and eFuse board selection

### Validation

- Verified indoor eFuse `0xA5` selects `ONE_INDOOR` with a conflicting outdoor model
- Verified outdoor eFuse `0x5A` selects `OPEN_AIR_OUTDOOR`
- Validated Python syntax, JSON syntax, formatting, and Git diff checks
- Firmware build/tests not run