### PR TITLE
fix(cellular): persist registration progress across reboot

### DIFF
--- a/examples/OneOpenAir/OneOpenAir.ino
+++ b/examples/OneOpenAir/OneOpenAir.ino
@@ -165,7 +165,6 @@ static AirgradientClient::PayloadType getClientPayloadType();
 static AirgradientClient::CommonPayload buildCommonPayload(Measurements::Measures &mc);
 static void saveOperatorState();
 static void restoreOperatorState();
-static void clearSavedOperatorIfExhausted();
 
 AgSchedule dispLedSchedule(DISP_UPDATE_INTERVAL, updateDisplayAndLedBar);
 AgSchedule configSchedule(WIFI_SERVER_CONFIG_SYNC_INTERVAL, configurationUpdateSchedule);
@@ -1081,8 +1080,10 @@ static void restoreOperatorState() {
     return;
   }
   uint32_t opId = configuration.getCellOperatorId();
-  if (cellularCard->setOperators(ops.c_str(), opId)) {
-    Serial.printf("Restored operator state: id=%u, list=%s\n", opId, ops.c_str());
+  uint32_t failCount = configuration.getCellOperatorFailCount();
+  if (cellularCard->setOperators(ops.c_str(), opId, failCount)) {
+    Serial.printf("Restored operator state: id=%u, failCount=%u, list=%s\n", opId,
+                  failCount, ops.c_str());
   } else {
     Serial.println("Failed to restore operator state");
   }
@@ -1091,22 +1092,10 @@ static void restoreOperatorState() {
 static void saveOperatorState() {
   String ops = cellularCard->getSerializedOperators().c_str();
   uint32_t opId = cellularCard->getCurrentOperatorId();
-  configuration.setCellOperatorState(ops, opId);
-  Serial.printf("Saved operator state: id=%u, list=%s\n", opId, ops.c_str());
-}
-
-static void clearSavedOperatorIfExhausted() {
-  if (networkOption != UseCellular || cellularCard == nullptr) {
-    return;
-  }
-  if (!cellularCard->getSerializedOperators().empty() || cellularCard->getCurrentOperatorId() != 0) {
-    return;
-  }
-  if (configuration.getCellOperators().length() == 0 && configuration.getCellOperatorId() == 0) {
-    return;
-  }
-  configuration.setCellOperatorState("", 0);
-  Serial.println("Cleared saved operator state after registration exhaustion");
+  uint32_t failCount = cellularCard->getRegistrationFailCount();
+  configuration.setCellOperatorState(ops, opId, failCount);
+  Serial.printf("Saved operator state: id=%u, failCount=%u, list=%s\n", opId,
+                failCount, ops.c_str());
 }
 
 void initializeNetwork() {
@@ -1146,7 +1135,9 @@ void initializeNetwork() {
   agClient->setExtendedPmMeasures(configuration.isExtendedPmMeasuresEnabled());
 
   if (!agClient->begin(ag->deviceId().c_str(), getClientPayloadType())) {
-    clearSavedOperatorIfExhausted();
+    if (networkOption == UseCellular) {
+      saveOperatorState();
+    }
     oledDisplay.setText("Client", "initialization", "failed");
     delay(5000);
     oledDisplay.showRebooting();

--- a/examples/OneOpenAir/OneOpenAir.ino
+++ b/examples/OneOpenAir/OneOpenAir.ino
@@ -165,6 +165,7 @@ static AirgradientClient::PayloadType getClientPayloadType();
 static AirgradientClient::CommonPayload buildCommonPayload(Measurements::Measures &mc);
 static void saveOperatorState();
 static void restoreOperatorState();
+static void clearSavedOperatorIfExhausted();
 
 AgSchedule dispLedSchedule(DISP_UPDATE_INTERVAL, updateDisplayAndLedBar);
 AgSchedule configSchedule(WIFI_SERVER_CONFIG_SYNC_INTERVAL, configurationUpdateSchedule);
@@ -1094,6 +1095,20 @@ static void saveOperatorState() {
   Serial.printf("Saved operator state: id=%u, list=%s\n", opId, ops.c_str());
 }
 
+static void clearSavedOperatorIfExhausted() {
+  if (networkOption != UseCellular || cellularCard == nullptr) {
+    return;
+  }
+  if (!cellularCard->getSerializedOperators().empty() || cellularCard->getCurrentOperatorId() != 0) {
+    return;
+  }
+  if (configuration.getCellOperators().length() == 0 && configuration.getCellOperatorId() == 0) {
+    return;
+  }
+  configuration.setCellOperatorState("", 0);
+  Serial.println("Cleared saved operator state after registration exhaustion");
+}
+
 void initializeNetwork() {
   // Check if cellular module available
   agSerial = new AgSerial(Wire);
@@ -1131,6 +1146,7 @@ void initializeNetwork() {
   agClient->setExtendedPmMeasures(configuration.isExtendedPmMeasuresEnabled());
 
   if (!agClient->begin(ag->deviceId().c_str(), getClientPayloadType())) {
+    clearSavedOperatorIfExhausted();
     oledDisplay.setText("Client", "initialization", "failed");
     delay(5000);
     oledDisplay.showRebooting();

--- a/src/AgConfigure.cpp
+++ b/src/AgConfigure.cpp
@@ -67,6 +67,7 @@ JSON_PROP_DEF(extendedPmMeasures);
 JSON_PROP_DEF(satellites);
 JSON_PROP_DEF(cellOperators);
 JSON_PROP_DEF(cellOperatorId);
+JSON_PROP_DEF(cellOperatorFailCount);
 
 #define jprop_model_default                           ""
 #define jprop_country_default                         "TH"
@@ -88,6 +89,7 @@ JSON_PROP_DEF(cellOperatorId);
 #define jprop_extendedPmMeasures_default              false
 #define jprop_cellOperators_default                   ""
 #define jprop_cellOperatorId_default                  0
+#define jprop_cellOperatorFailCount_default           0
 
 JSONVar jconfig;
 
@@ -508,6 +510,7 @@ void Configuration::defaultConfig(void) {
   jconfig[jprop_extendedPmMeasures] = jprop_extendedPmMeasures_default;
   jconfig[jprop_cellOperators] = jprop_cellOperators_default;
   jconfig[jprop_cellOperatorId] = jprop_cellOperatorId_default;
+  jconfig[jprop_cellOperatorFailCount] = jprop_cellOperatorFailCount_default;
 
   // PM2.5 default correction
   pmCorrection.algorithm = COR_ALGO_PM_NONE;
@@ -1651,6 +1654,14 @@ void Configuration::toConfig(const char *buf) {
     logInfo("toConfig: cellOperatorId changed");
   }
 
+  // Validate cellOperatorFailCount (number)
+  if (JSON.typeof_(jconfig[jprop_cellOperatorFailCount]) != "number" &&
+      JSON.typeof_(jconfig[jprop_cellOperatorFailCount]) != "undefined") {
+    jconfig[jprop_cellOperatorFailCount] = jprop_cellOperatorFailCount_default;
+    changed = true;
+    logInfo("toConfig: cellOperatorFailCount changed");
+  }
+
   if (changed) {
     saveConfig();
   }
@@ -1814,9 +1825,19 @@ uint32_t Configuration::getCellOperatorId(void) {
   return id;
 }
 
-void Configuration::setCellOperatorState(const String &operators, uint32_t operatorId) {
+uint32_t Configuration::getCellOperatorFailCount(void) {
+  if (JSON.typeof_(jconfig[jprop_cellOperatorFailCount]) != "number") {
+    return 0;
+  }
+  uint32_t failCount = (uint32_t)(int)jconfig[jprop_cellOperatorFailCount];
+  return failCount;
+}
+
+void Configuration::setCellOperatorState(const String &operators, uint32_t operatorId,
+                                         uint32_t failCount) {
   jconfig[jprop_cellOperators] = operators;
   jconfig[jprop_cellOperatorId] = (int)operatorId;
+  jconfig[jprop_cellOperatorFailCount] = (int)failCount;
   saveConfig();
   logInfo("Cellular operator state saved");
 }

--- a/src/AgConfigure.h
+++ b/src/AgConfigure.h
@@ -138,7 +138,9 @@ public:
   const String *getSatellites() const;
   String getCellOperators(void);
   uint32_t getCellOperatorId(void);
-  void setCellOperatorState(const String &operators, uint32_t operatorId);
+  uint32_t getCellOperatorFailCount(void);
+  void setCellOperatorState(const String &operators, uint32_t operatorId,
+                            uint32_t failCount = 0);
 
 private:
   ConfigurationUpdatedCallback_t _callback;


### PR DESCRIPTION
### Summary
Persist cellular operator registration progress across OneOpenAir reboots so partial attempts resume and final exhaustion triggers a fresh scan.

### Changes
- Store and restore the cellular registration fail count with operator state
- Save operator state when cellular initialization fails
- Update airgradient-client with registration retry and operator-scan fixes

### Validation
- Manually tested cellular operator scan handling on hardware
- Automated build not run